### PR TITLE
Bug fix: OPFLOW_LINEFLOW_PENALTY

### DIFF
--- a/src/opflow/model/power_bal_polar/pbpol.cpp
+++ b/src/opflow/model/power_bal_polar/pbpol.cpp
@@ -3173,6 +3173,8 @@ PetscErrorCode OPFLOWModelSetUp_PBPOL(OPFLOW opflow) {
     if (!line->isdcline) {
       /* Set starting location for slack variable */
       if (opflow->allow_lineflow_violation) {
+        ierr = PSLINEGetVariableLocation(line, &loc);
+        CHKERRQ(ierr);
         line->startxslackloc = loc;
       }
       line->startineqloc = ineqloc;

--- a/tests/functionality/opflow/CMakeLists.txt
+++ b/tests/functionality/opflow/CMakeLists.txt
@@ -131,7 +131,6 @@ if(EXAGO_INSTALL_TESTS)
     ${CMAKE_SOURCE_DIR}
     DEPENDS
     IPOPT
-    HIOP
   )
 
   exago_add_test(


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [x] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [x] Source code
- [x] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

This fixes a bug where out-of-bound values were being added to the inequality constraint Jacobian.
The location is being accessed at https://github.com/ORNL/ExaGO/blob/6c082a037f139432ed248f2823b61d8f90fe3411/src/opflow/model/power_bal_polar/pbpol.cpp#L1384

so incorrectly setting it at 
https://github.com/ORNL/ExaGO/blob/6c082a037f139432ed248f2823b61d8f90fe3411/src/opflow/model/power_bal_polar/pbpol.cpp#L3176

**Linked Issue(s)**
See also this [issue](https://github.com/pnnl/ExaGO/issues/169).