### PR TITLE
Fix PETSc compile warnings

### DIFF
--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -1,5 +1,5 @@
 # https://spack.readthedocs.io/en/latest/binary_caches.html#spack-build-cache-for-github-actions
-name: Spack Ubunutu x86_64 Buildcache
+name: CPU Tests
 
 env:
   SPACK_COLOR: always

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ if(EXAGO_ENABLE_PETSC)
   set(ENV{PKG_CONFIG_PATH}
       ${PETSC_DIR}/lib/pkgconfig:${PETSC_DIR}/${PETSC_ARCH}/lib/pkgconfig
   )
-  pkg_check_modules(PETSC REQUIRED IMPORTED_TARGET PETSc)
+  pkg_check_modules(PETSC REQUIRED IMPORTED_TARGET PETSc>=3.24)
   set(EXAGO_HAVE_PETSC 1)
   set(ENV{PKG_CONFIG_PATH} ${PKG_CONFIG_PATH_save})
 endif()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,11 +42,11 @@ Dependencies are broken down into three categories:
 
 | Dependency | Dependency Version | CMake Variable (if applicable) | Notes |
 |---|---|---|---|
-| PETSC | ==3.16 | `EXAGO_ENABLE_PETSC`. `PETSC_DIR` sets the PETSC installation prefix. | Required. PETSC needs to be built with MPI if building ExaGO with MPI. [See the linked document for more information on building PETSC for ExaGO.](docs/web/petsc_install.md) |
+| PETSC | >=3.24.0 | `EXAGO_ENABLE_PETSC`. `PETSC_DIR` sets the PETSC installation prefix. | Required. PETSC needs to be built with MPI if building ExaGO with MPI. [See the linked document for more information on building PETSC for ExaGO.](docs/web/petsc_install.md) |
 | CMake | >=3.18 | N/A |  |
 | blas |  | `BLAS_LIBRARIES` sets the blas libraries. | ExaGO uses the builtin [`FindBLAS` cmake module](https://cmake.org/cmake/help/latest/module/FindBLAS.html). Please refer to the linked documentation. |
 | MPI | >=3 | `EXAGO_ENABLE_MPI`. `MPI_HOME` sets the MPI installation prefix. | Optional. ExaGO uses the builtin [`FindMPI` cmake module](https://cmake.org/cmake/help/latest/module/FindMPI.html). |
-| Python | >=3.5 | `EXAGO_ENABLE_PYTHON`, `Python3_DIR` | ExaGO uses builtin [`FindPython` cmake module](https://cmake.org/cmake/help/latest/module/FindPython.html). Please refer to linked documentation. |
+| Python | >=3.12 | `EXAGO_ENABLE_PYTHON`, `Python3_DIR` | ExaGO uses builtin [`FindPython` cmake module](https://cmake.org/cmake/help/latest/module/FindPython.html). Please refer to linked documentation. |
 
 #### Third-Party Solvers
 
@@ -55,8 +55,8 @@ Additional documentation on installing these dependencies are linked below.
 
 | Dependency | Dependency Version | CMake Variable (if applicable) | Notes |
 |---|---|---|---|
-| HiOp | v0.5.3 | `EXAGO_ENABLE_HIOP`, `HIOP_DIR` | Optional, needs to be built with CUDA and MPI if using those options. [See HiOp repo linked here for more information.](https://github.com/LLNL/hiop) |
-| Ipopt | >=3.12 | `EXAGO_ENABLE_IPOPT`, `IPOPT_DIR` | Needs to be built with COINHSL if using HiOp sparse linear algebra. [See the linked document for more information on building Ipopt for ExaGO](./docs/web/ipopt_install.md), [and see this link for PETSC documentation.](https://petsc.org/release/)|
+| HiOp | >=1.0 | `EXAGO_ENABLE_HIOP`, `HIOP_DIR` | Optional, needs to be built with CUDA and MPI if using those options. [See HiOp repo linked here for more information.](https://github.com/LLNL/hiop) |
+| Ipopt | >=3.14 | `EXAGO_ENABLE_IPOPT`, `IPOPT_DIR` | Needs to be built with COINHSL if using HiOp sparse linear algebra. [See the linked document for more information on building Ipopt for ExaGO](./docs/web/ipopt_install.md), [and see this link for PETSC documentation.](https://petsc.org/release/)|
 
 #### GPU-Related Dependencies
 

--- a/docs/petsc-dependencies/dmnetwork.md
+++ b/docs/petsc-dependencies/dmnetwork.md
@@ -120,7 +120,7 @@ PetscSectionDestroy(PetscSection section)
 
 1. Get the PetscSection associated with the DM
 ```
-DMGetSection(DM dm, PetscSection *section)
+DMGetLocalSection(DM dm, PetscSection *section)
 ```
 
 2. Get the global section for the DM
@@ -130,7 +130,7 @@ DMGetGlobalSection(DM dm, PetscSection *globalsection)
 
 3. Set a section on the DM
 ```
-DMSetSection(DM dm,PetscSection section)
+DMSetLocalSection(DM dm,PetscSection section)
 ```
 
 ## Solve stage

--- a/interfaces/python/exago_python_opflow.cpp
+++ b/interfaces/python/exago_python_opflow.cpp
@@ -350,7 +350,7 @@ void init_exago_opflow(pybind11::module &m) {
              std::copy(kvlevels.begin(), kvlevels.end(),
                        std::back_inserter(tmp));
              ierr = OPFLOWSetLinesMonitored(
-                 w.opf, 1, NULL, NULL, static_cast<PetscInt>(kvlevels.size()),
+                 w.opf, 1, 0, NULL, static_cast<PetscInt>(kvlevels.size()),
                  &tmp[0], NULL);
              ExaGOCheckError(ierr);
            })
@@ -362,7 +362,7 @@ void init_exago_opflow(pybind11::module &m) {
            [](OPFLOW_wrapper &w, const int &nkvlevels,
               const std::string &monitorfile) {
              PetscErrorCode ierr;
-             ierr = OPFLOWSetLinesMonitored(w.opf, 1, NULL, NULL,
+             ierr = OPFLOWSetLinesMonitored(w.opf, 1, 0, NULL,
                                             (PetscInt)nkvlevels, NULL,
                                             monitorfile.c_str());
              ExaGOCheckError(ierr);

--- a/interfaces/python/exago_python_opflow.cpp
+++ b/interfaces/python/exago_python_opflow.cpp
@@ -362,9 +362,9 @@ void init_exago_opflow(pybind11::module &m) {
            [](OPFLOW_wrapper &w, const int &nkvlevels,
               const std::string &monitorfile) {
              PetscErrorCode ierr;
-             ierr = OPFLOWSetLinesMonitored(w.opf, 1, 0, NULL,
-                                            (PetscInt)nkvlevels, NULL,
-                                            monitorfile.c_str());
+             ierr =
+                 OPFLOWSetLinesMonitored(w.opf, 1, 0, NULL, (PetscInt)nkvlevels,
+                                         NULL, monitorfile.c_str());
              ExaGOCheckError(ierr);
            })
 

--- a/src/opflow/interface/opflow.cpp
+++ b/src/opflow/interface/opflow.cpp
@@ -648,7 +648,7 @@ PetscErrorCode OPFLOWSetUpInitPflow(OPFLOW opflow) {
   CHKERRQ(ierr);
 
   /* Get default sections associated with this plex */
-  ierr = DMGetSection(plexdm, &opflow->defaultsection);
+  ierr = DMGetLocalSection(plexdm, &opflow->defaultsection);
   CHKERRQ(ierr);
   ierr = PetscObjectReference((PetscObject)opflow->defaultsection);
   CHKERRQ(ierr);
@@ -659,7 +659,7 @@ PetscErrorCode OPFLOWSetUpInitPflow(OPFLOW opflow) {
   CHKERRQ(ierr);
 
   /* Set the new section created for initial power flow */
-  ierr = DMSetSection(plexdm, opflow->initpflowpsection);
+  ierr = DMSetLocalSection(plexdm, opflow->initpflowpsection);
   CHKERRQ(ierr);
   ierr = DMGetGlobalSection(plexdm, &opflow->initpflowpglobsection);
   CHKERRQ(ierr);
@@ -680,7 +680,7 @@ PetscErrorCode OPFLOWSetUpInitPflow(OPFLOW opflow) {
   CHKERRQ(ierr);
 
   /* Reset the sections */
-  ierr = DMSetSection(plexdm, opflow->defaultsection);
+  ierr = DMSetLocalSection(plexdm, opflow->defaultsection);
   CHKERRQ(ierr);
   ierr = DMSetGlobalSection(plexdm, opflow->defaultglobalsection);
   CHKERRQ(ierr);
@@ -720,7 +720,7 @@ PetscErrorCode OPFLOWComputePrePflow(OPFLOW opflow, PetscBool *converged) {
   CHKERRQ(ierr);
 
   /* Set the new section created for initial power flow. */
-  ierr = DMSetSection(plexdm, opflow->initpflowpsection);
+  ierr = DMSetLocalSection(plexdm, opflow->initpflowpsection);
   CHKERRQ(ierr);
   ierr = DMSetGlobalSection(plexdm, opflow->initpflowpglobsection);
   CHKERRQ(ierr);
@@ -745,7 +745,7 @@ PetscErrorCode OPFLOWComputePrePflow(OPFLOW opflow, PetscBool *converged) {
 
   /*
      Update the ref. counts for init pflow sections so that they do not
-     get destroyed when DMSetSection is called
+     get destroyed when DMSetLocalSection is called
   */
   ierr = PetscObjectReference((PetscObject)opflow->initpflowpsection);
   CHKERRQ(ierr);
@@ -753,7 +753,7 @@ PetscErrorCode OPFLOWComputePrePflow(OPFLOW opflow, PetscBool *converged) {
   CHKERRQ(ierr);
 
   /* Reset the sections */
-  ierr = DMSetSection(plexdm, opflow->defaultsection);
+  ierr = DMSetLocalSection(plexdm, opflow->defaultsection);
   CHKERRQ(ierr);
   ierr = DMSetGlobalSection(plexdm, opflow->defaultglobalsection);
   CHKERRQ(ierr);
@@ -1346,7 +1346,7 @@ PetscErrorCode OPFLOWSetNumConstraints(OPFLOW opflow, PetscInt *branchnconeq,
   /* (i) */
   ierr = DMNetworkGetPlex(networkdm, &plexdm);
   CHKERRQ(ierr);
-  ierr = DMGetSection(plexdm, &varsection);
+  ierr = DMGetLocalSection(plexdm, &varsection);
   CHKERRQ(ierr);
   ierr = PetscObjectReference((PetscObject)varsection);
   CHKERRQ(ierr);
@@ -1356,7 +1356,7 @@ PetscErrorCode OPFLOWSetNumConstraints(OPFLOW opflow, PetscInt *branchnconeq,
   CHKERRQ(ierr);
 
   /*  (ii) */
-  ierr = DMSetSection(plexdm, buseqconsection);
+  ierr = DMSetLocalSection(plexdm, buseqconsection);
   CHKERRQ(ierr);
 
   /* (iii) */
@@ -1375,7 +1375,7 @@ PetscErrorCode OPFLOWSetNumConstraints(OPFLOW opflow, PetscInt *branchnconeq,
   }
 
   /* (v) */
-  ierr = DMSetSection(plexdm, varsection);
+  ierr = DMSetLocalSection(plexdm, varsection);
   CHKERRQ(ierr);
   ierr = DMSetGlobalSection(plexdm, varglobsection);
   CHKERRQ(ierr);
@@ -1464,7 +1464,7 @@ PetscErrorCode OPFLOWSetNumVariables(OPFLOW opflow, PetscInt *busnvararray,
 
   ierr = DMNetworkGetPlex(networkdm, &plexdm);
   CHKERRQ(ierr);
-  ierr = DMGetSection(plexdm, &oldvarsection);
+  ierr = DMGetLocalSection(plexdm, &oldvarsection);
   CHKERRQ(ierr);
   ierr = PetscSectionDestroy(&oldvarsection);
   CHKERRQ(ierr);
@@ -1478,7 +1478,7 @@ PetscErrorCode OPFLOWSetNumVariables(OPFLOW opflow, PetscInt *busnvararray,
   networkdmdata->DofSection = 0;
 
   /* Set the section with number of variables */
-  ierr = DMSetSection(plexdm, varsection);
+  ierr = DMSetLocalSection(plexdm, varsection);
   CHKERRQ(ierr);
   ierr = DMGetGlobalSection(plexdm, &globalvarsection);
   CHKERRQ(ierr);
@@ -3073,7 +3073,7 @@ PetscErrorCode OPFLOWSetLinesMonitored(OPFLOW opflow, PetscInt mon_mode,
   PetscFunctionBegin;
 
   if (mon_mode < 0 || mon_mode > 2) {
-    SETERRQ1(opflow->comm->type, PETSC_ERR_SUP,
+    SETERRQ(opflow->comm->type, PETSC_ERR_SUP,
              "mon_mode input for OPFLOWSetLinesMonitored should \
             be either 0 (list of given lines), 1 (list of KV levels), 2 (list from input file. Incorrect \
             mon_mode = %d given",

--- a/src/opflow/interface/opflow.cpp
+++ b/src/opflow/interface/opflow.cpp
@@ -3074,10 +3074,10 @@ PetscErrorCode OPFLOWSetLinesMonitored(OPFLOW opflow, PetscInt mon_mode,
 
   if (mon_mode < 0 || mon_mode > 2) {
     SETERRQ(opflow->comm->type, PETSC_ERR_SUP,
-             "mon_mode input for OPFLOWSetLinesMonitored should \
+            "mon_mode input for OPFLOWSetLinesMonitored should \
             be either 0 (list of given lines), 1 (list of KV levels), 2 (list from input file. Incorrect \
             mon_mode = %d given",
-             mon_mode);
+            mon_mode);
   }
 
   if (mon_mode == 0) {

--- a/src/ps/ps.cpp
+++ b/src/ps/ps.cpp
@@ -66,7 +66,7 @@ PetscErrorCode PSCheckandSetRefBus(PS ps) {
     }
   }
 
-  ierr = MPI_Allreduce(&pshaslocalref, &pshasref, 1, MPIU_BOOL, MPI_LOR,
+  ierr = MPI_Allreduce(&pshaslocalref, &pshasref, 1, MPI_C_BOOL, MPI_LOR,
                        ps->comm->type);
   CHKERRQ(ierr);
 

--- a/src/ps/psislanding.cpp
+++ b/src/ps/psislanding.cpp
@@ -48,7 +48,7 @@ PetscErrorCode PSIslandCheckandSetRefBus(PS ps, PetscInt isnum) {
     }
   }
 
-  ierr = MPI_Allreduce(&pshaslocalref, &pshasref, 1, MPIU_BOOL, MPI_LOR,
+  ierr = MPI_Allreduce(&pshaslocalref, &pshasref, 1, MPI_C_BOOL, MPI_LOR,
                        ps->comm->type);
   CHKERRQ(ierr);
 


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [x] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [x] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [x] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [x] Source code
- [x] CMake build system
- [ ] Spack configuration
- [x] Web docs
- [ ] Manual
- [ ] Other

**Summary**

Fix compile-time warnings from PETSc. These are mainly deprecation warnings and one warning where `NULL` is used in place of zero integer argument.

This PR does _not_ address warnings oming from pybind11.