### PR TITLE
Fix petsc function stack

### DIFF
--- a/src/opflow/model/power_bal_hiop/paramsrajahiop.cpp
+++ b/src/opflow/model/power_bal_hiop/paramsrajahiop.cpp
@@ -317,7 +317,6 @@ int LINEParamsRajaHiop::allocate(OPFLOW opflow) {
   const PSBUS *connbuses;
   PSBUS busf, bust;
 
-  PetscFunctionBegin;
   ierr = PSGetNumActiveLines(ps, &nlineON, NULL);
   CHKERRQ(ierr);
 
@@ -545,7 +544,7 @@ int LOADParamsRajaHiop::allocate(OPFLOW opflow) {
 
 #endif
 
-  return (0);
+  return 0;
 }
 
 int GENParamsRajaHiop::destroy(OPFLOW opflow) {
@@ -662,8 +661,6 @@ int GENParamsRajaHiop::allocate(OPFLOW opflow) {
   PSBUS bus;
   PetscInt i, j;
   PetscErrorCode ierr;
-
-  PetscFunctionBegin;
 
   /* Get the number of active generators (STATUS ON) */
   ierr = PSGetNumActiveGenerators(ps, &ngenON, NULL);

--- a/src/opflow/model/power_bal_hiop/pbpolhiopkernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolhiopkernels.cpp
@@ -574,6 +574,8 @@ PetscErrorCode OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLHIOP(
   LOADParams *loadparams = &pbpolhiop->loadparams;
   BUSParams *busparams = &pbpolhiop->busparams;
 
+  PetscFunctionBegin;
+
   if (iJacS != NULL && jJacS != NULL) {
 
     /* Power Imbalance Contributions (BUS Second Variables?) */
@@ -674,6 +676,8 @@ PetscErrorCode OPFLOWComputeSparseInequalityConstraintJacobian_PBPOLHIOP(
   (void)opflow;
   (void)x;
 
+  PetscFunctionBegin;
+
   if (iJacS != NULL && jJacS != NULL) {
   }
 
@@ -702,6 +706,8 @@ PetscErrorCode OPFLOWComputeSparseHessian_PBPOLHIOP(OPFLOW opflow,
   double weight = opflow->weight;
   PetscInt flps = 0;
   int loc;
+
+  PetscFunctionBegin;
 
   if (iHSS != NULL && jHSS != NULL) {
 
@@ -1814,6 +1820,8 @@ PetscErrorCode OPFLOWComputeDenseHessian_PBPOLHIOP(OPFLOW opflow,
   PetscErrorCode ierr;
   int nxdense = opflow->nxdense;
 
+  PetscFunctionBegin;
+
   if (!HDD)
     PetscFunctionReturn(0);
 
@@ -1842,6 +1850,8 @@ PetscErrorCode OPFLOWSolutionCallback_PBPOLHIOP(
   (void)obj_value;
   PetscErrorCode ierr;
   PetscScalar *x, *lam, *g;
+
+  PetscFunctionBegin;
 
   ierr = VecGetArray(opflow->X, &x);
   CHKERRQ(ierr);

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopkernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopkernels.cpp
@@ -623,6 +623,8 @@ PetscErrorCode OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOP(
   LOADParamsRajaHiop *loadparams = &pbpolrajahiop->loadparams;
   BUSParamsRajaHiop *busparams = &pbpolrajahiop->busparams;
 
+  PetscFunctionBegin;
+
   //  PetscPrintf(MPI_COMM_SELF,"Entered sparse jacobian\n");
   if (iJacS_dev != NULL && jJacS_dev != NULL) {
 
@@ -777,6 +779,8 @@ PetscErrorCode OPFLOWComputeSparseHessian_PBPOLRAJAHIOP(
   double weight = opflow->weight;
   PetscInt flps = 0;
   //  PetscPrintf(MPI_COMM_SELF,"Entered sparse Hessian\n");
+
+  PetscFunctionBegin;
 
   if (iHSS_dev != NULL && jHSS_dev != NULL) {
 
@@ -2077,6 +2081,8 @@ PetscErrorCode OPFLOWComputeDenseHessian_PBPOLRAJAHIOP(OPFLOW opflow,
   PetscErrorCode ierr;
   int nxdense = opflow->nxdense;
 
+  PetscFunctionBegin;
+
   if (!HDD_dev)
     PetscFunctionReturn(0);
 
@@ -2107,6 +2113,8 @@ PetscErrorCode OPFLOWSolutionCallback_PBPOLRAJAHIOP(
 
   PetscErrorCode ierr;
   PetscScalar *x, *lam, *g;
+
+  PetscFunctionBegin;
 
   auto &resmgr = umpire::ResourceManager::getInstance();
   umpire::Allocator h_allocator_ = resmgr.getAllocator("HOST");

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopkernels.h
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopkernels.h
@@ -24,4 +24,4 @@ void registerWith(T *ptr, SizeType N, umpire::ResourceManager &resmgr,
   resmgr.registerAllocation(ptr, record);
 }
 
-#endif // EXAGO_ENABLE_HIOP
+#endif // EXAGO_ENABLE_RAJA

--- a/src/ps/ps.cpp
+++ b/src/ps/ps.cpp
@@ -1008,7 +1008,8 @@ PetscErrorCode PSSetUp(PS ps) {
   //    lineconn[0][2 * (Nlines+i)    ] = ps->isolated_buses[i];
   //    lineconn[0][2 * (Nlines+i) + 1] = 0;
   //  }
-  //  ierr = PetscFree(ps->isolated_buses);
+  ierr = PetscFree(ps->isolated_buses);
+  CHKERRQ(ierr);
 
   /* Set sizes for the network and provide edge connectivity information */
   ierr = DMNetworkSetNumSubNetworks(networkdm, PETSC_DECIDE, 1);

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -1208,6 +1208,7 @@ PetscErrorCode SCOPFLOWGetNumVariablesandConstraints(SCOPFLOW scopflow,
  * @param [in] iter pointer to solver iteration variable
  */
 PetscErrorCode SCOPFLOWGetNumIterations(SCOPFLOW scopflow, PetscInt *iter) {
+  PetscFunctionBegin;
   *iter = scopflow->numiter;
   PetscFunctionReturn(0);
 }

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -354,8 +354,7 @@ PetscErrorCode SCOPFLOWSetNetworkData(SCOPFLOW scopflow, const char netfile[]) {
 
   PetscFunctionBegin;
 
-  ierr = PetscMemcpy(scopflow->netfile, netfile,
-                     PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(scopflow->netfile, netfile);
   CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
@@ -374,8 +373,7 @@ PetscErrorCode SCOPFLOWSetPLoadData(SCOPFLOW scopflow, const char profile[]) {
 
   PetscFunctionBegin;
 
-  ierr =
-      PetscMemcpy(scopflow->pload, profile, PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(scopflow->pload, profile);
   CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
@@ -394,8 +392,7 @@ PetscErrorCode SCOPFLOWSetQLoadData(SCOPFLOW scopflow, const char profile[]) {
 
   PetscFunctionBegin;
 
-  ierr =
-      PetscMemcpy(scopflow->qload, profile, PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(scopflow->qload, profile);
   CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
@@ -415,8 +412,7 @@ PetscErrorCode SCOPFLOWSetWindGenProfile(SCOPFLOW scopflow,
 
   PetscFunctionBegin;
 
-  ierr = PetscMemcpy(scopflow->windgen, profile,
-                     PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(scopflow->windgen, profile);
   CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
@@ -1371,8 +1367,7 @@ SCOPFLOWSetContingencyData(SCOPFLOW scopflow,
 
   PetscFunctionBegin;
 
-  ierr = PetscMemcpy(scopflow->ctgcfile, ctgcfile,
-                     PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(scopflow->ctgcfile, ctgcfile);
   CHKERRQ(ierr);
   scopflow->ctgcfileformat = ctgcfileformat;
   scopflow->ctgcfileset = PETSC_TRUE;
@@ -1394,8 +1389,7 @@ PetscErrorCode SCOPFLOWSetGICData(SCOPFLOW scopflow, const char gicfile[]) {
 
   PetscFunctionBegin;
 
-  ierr = PetscMemcpy(scopflow->gicfile, gicfile,
-                     PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(scopflow->gicfile, gicfile);
   CHKERRQ(ierr);
   scopflow->gicfileset = PETSC_TRUE;
 

--- a/src/sopflow/interface/sopflow.cpp
+++ b/src/sopflow/interface/sopflow.cpp
@@ -434,8 +434,7 @@ PetscErrorCode SOPFLOWSetNetworkData(SOPFLOW sopflow, const char netfile[]) {
 
   PetscFunctionBegin;
 
-  ierr =
-      PetscMemcpy(sopflow->netfile, netfile, PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(sopflow->netfile, netfile);
   CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
@@ -467,8 +466,7 @@ PetscErrorCode SOPFLOWSetContingencyData(SOPFLOW sopflow,
   }
   CHKERRQ(ierr);
 
-  ierr =
-      PetscMemcpy(sopflow->ctgfile, ctgfile, PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(sopflow->ctgfile, ctgfile);
   CHKERRQ(ierr);
   sopflow->ctgcfileset = PETSC_TRUE;
   PetscFunctionReturn(0);
@@ -486,8 +484,7 @@ PetscErrorCode SOPFLOWSetWindGenProfile(SOPFLOW sopflow, const char windgen[]) {
 
   PetscFunctionBegin;
 
-  ierr =
-      PetscMemcpy(sopflow->windgen, windgen, PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(sopflow->windgen, windgen);
   CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
@@ -563,8 +560,7 @@ SOPFLOWSetContingencyData(SOPFLOW sopflow,
 
   PetscFunctionBegin;
 
-  ierr = PetscMemcpy(sopflow->ctgcfile, ctgcfile,
-                     PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(sopflow->ctgcfile, ctgcfile);
   CHKERRQ(ierr);
   sopflow->ctgcfileformat = ctgcfileformat;
   sopflow->ctgcfileset = PETSC_TRUE;
@@ -1468,14 +1464,12 @@ PetscErrorCode SOPFLOWSetLoadProfiles(SOPFLOW sopflow,
   PetscFunctionBegin;
 
   if (ploadprofile) {
-    ierr = PetscMemcpy(sopflow->ploadprofile, ploadprofile,
-                       PETSC_MAX_PATH_LEN * sizeof(char));
+    ierr = PetscStrcpy(sopflow->ploadprofile, ploadprofile);
     CHKERRQ(ierr);
   }
 
   if (qloadprofile) {
-    ierr = PetscMemcpy(sopflow->qloadprofile, qloadprofile,
-                       PETSC_MAX_PATH_LEN * sizeof(char));
+    ierr = PetscStrcpy(sopflow->qloadprofile, qloadprofile);
     CHKERRQ(ierr);
   }
 

--- a/src/sopflow/interface/sopflow.cpp
+++ b/src/sopflow/interface/sopflow.cpp
@@ -1421,6 +1421,7 @@ PetscErrorCode SOPFLOWGetConvergenceStatus(SOPFLOW sopflow, PetscBool *status) {
   SOPFLOWGetNumIterations - Returns the number of iterations for given solver
 */
 PetscErrorCode SOPFLOWGetNumIterations(SOPFLOW sopflow, PetscInt *iter) {
+  PetscFunctionBegin;
   *iter = sopflow->numiter;
   PetscFunctionReturn(0);
 }

--- a/src/sopflow/interface/sopflowscen.cpp
+++ b/src/sopflow/interface/sopflowscen.cpp
@@ -25,8 +25,7 @@ PetscErrorCode SOPFLOWSetScenarioData(SOPFLOW sopflow,
 
   PetscFunctionBegin;
 
-  ierr = PetscMemcpy(sopflow->scenfile, scenfile,
-                     PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(sopflow->scenfile, scenfile);
   CHKERRQ(ierr);
 
   sopflow->scenfileformat = scenfileformat;

--- a/src/tcopflow/interface/tcopflow.cpp
+++ b/src/tcopflow/interface/tcopflow.cpp
@@ -34,15 +34,13 @@ PetscErrorCode TCOPFLOWSetLoadProfiles(TCOPFLOW tcopflow,
   PetscFunctionBegin;
 
   if (ploadprofile) {
-    ierr = PetscMemcpy(tcopflow->ploadprofile, ploadprofile,
-                       PETSC_MAX_PATH_LEN * sizeof(char));
+    ierr = PetscStrcpy(tcopflow->ploadprofile, ploadprofile);
     CHKERRQ(ierr);
     tcopflow->ploadprofileset = PETSC_TRUE;
   }
 
   if (qloadprofile) {
-    ierr = PetscMemcpy(tcopflow->qloadprofile, qloadprofile,
-                       PETSC_MAX_PATH_LEN * sizeof(char));
+    ierr = PetscStrcpy(tcopflow->qloadprofile, qloadprofile);
     CHKERRQ(ierr);
     tcopflow->qloadprofileset = PETSC_TRUE;
   }
@@ -64,8 +62,7 @@ PetscErrorCode TCOPFLOWSetWindGenProfiles(TCOPFLOW tcopflow,
   PetscFunctionBegin;
 
   if (windgenprofile) {
-    ierr = PetscMemcpy(tcopflow->windgenprofile, windgenprofile,
-                       PETSC_MAX_PATH_LEN * sizeof(char));
+    ierr = PetscStrcpy(tcopflow->windgenprofile, windgenprofile);
     CHKERRQ(ierr);
     tcopflow->windgenprofileset = PETSC_TRUE;
   }
@@ -318,8 +315,7 @@ PetscErrorCode TCOPFLOWSetNetworkData(TCOPFLOW tcopflow, const char netfile[]) {
 
   PetscFunctionBegin;
 
-  ierr = PetscMemcpy(tcopflow->netfile, netfile,
-                     PETSC_MAX_PATH_LEN * sizeof(char));
+  ierr = PetscStrcpy(tcopflow->netfile, netfile);
   CHKERRQ(ierr);
 
   PetscFunctionReturn(0);

--- a/src/tcopflow/model/genramp/genramp.cpp
+++ b/src/tcopflow/model/genramp/genramp.cpp
@@ -478,6 +478,8 @@ PetscErrorCode TCOPFLOWComputeGradient_GENRAMP(TCOPFLOW tcopflow, Vec X,
   ierr = VecGetArray(Grad, &grad);
   CHKERRQ(ierr);
 
+  PetscFunctionBegin;
+
   for (i = 0; i < tcopflow->Nt; i++) {
     opflow = tcopflow->opflows[i];
     xi = x + tcopflow->xstarti[i];

--- a/tests/functionality/scopflow/selfcheck.cpp
+++ b/tests/functionality/scopflow/selfcheck.cpp
@@ -230,17 +230,17 @@ struct ScopflowFunctionalityTests
     }
     ExaGOCheckError(ierr);
 
-    // Prepend installation directory to network path
+    // Prepend installation directory to pload path
     resolve_datafiles_path(params.pload);
     ierr = SCOPFLOWSetPLoadData(scopflow, params.pload.c_str());
     ExaGOCheckError(ierr);
 
-    // Prepend installation directory to network path
+    // Prepend installation directory to qload path
     resolve_datafiles_path(params.qload);
     ierr = SCOPFLOWSetQLoadData(scopflow, params.qload.c_str());
     ExaGOCheckError(ierr);
 
-    // Prepend installation directory to network path
+    // Prepend installation directory to windgen path
     resolve_datafiles_path(params.windgen);
     ierr = SCOPFLOWSetWindGenProfile(scopflow, params.windgen.c_str());
     ExaGOCheckError(ierr);


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [ ] Documentation
- [x] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [x] Other

**This MR updates**
- [ ] Header files
- [x] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

This fixes mismatching `PetscFunctionBegin` and `PetscFunctionReturn`. This is needed to get correct stack traces when PETSc is configured with `--with-debugging=1`. 

A couple of things that were flagged after this fix:
- `PetscMemcpy` for some paths that are no longer declared with `PETSC_MAX_PATH_LEN`, which I replaced with `PetscStrcpy`.
- A missing (incorrectly commented out) `PetscFree`.
