### PR TITLE
Sort equality constraints Jacobian entries for hiopsparse_gpu

### DIFF
--- a/src/opflow/model/power_bal_hiop/paramsrajahiop.cpp
+++ b/src/opflow/model/power_bal_hiop/paramsrajahiop.cpp
@@ -900,10 +900,12 @@ void PbpolModelRajaHiop::destroy(OPFLOW opflow) {
 
     auto &resmgr = umpire::ResourceManager::getInstance();
     umpire::Allocator h_allocator_ = resmgr.getAllocator("HOST");
+    umpire::Allocator d_allocator_ = resmgr.getAllocator("DEVICE");
 
     h_allocator_.deallocate(i_jaceq);
     h_allocator_.deallocate(j_jaceq);
     h_allocator_.deallocate(perm_jaceq);
+    d_allocator_.deallocate(perm_jaceq_dev);
 
     h_allocator_.deallocate(i_hess);
     h_allocator_.deallocate(j_hess);

--- a/src/opflow/model/power_bal_hiop/paramsrajahiop.cpp
+++ b/src/opflow/model/power_bal_hiop/paramsrajahiop.cpp
@@ -21,7 +21,7 @@ int BUSParamsRajaHiop::destroy(OPFLOW opflow) {
   h_allocator_.deallocate(bl);
   h_allocator_.deallocate(xidx);
   h_allocator_.deallocate(gidx);
-  h_allocator_.deallocate(eqjacsp_selfidx);
+  h_allocator_.deallocate(eqjacsp_idx);
   if (opflow->include_powerimbalance_variables) {
     h_allocator_.deallocate(xidxpimb);
     h_allocator_.deallocate(powerimbalance_penalty);
@@ -46,7 +46,7 @@ int BUSParamsRajaHiop::destroy(OPFLOW opflow) {
   d_allocator_.deallocate(bl_dev_);
   d_allocator_.deallocate(xidx_dev_);
   d_allocator_.deallocate(gidx_dev_);
-  d_allocator_.deallocate(eqjacsp_selfidx_dev_);
+  d_allocator_.deallocate(eqjacsp_idx_dev_);
   if (opflow->include_powerimbalance_variables) {
     d_allocator_.deallocate(xidxpimb_dev_);
     d_allocator_.deallocate(powerimbalance_penalty_dev_);
@@ -86,7 +86,7 @@ int BUSParamsRajaHiop::copy(OPFLOW opflow) {
 
   resmgr.copy(xidx_dev_, xidx);
   resmgr.copy(gidx_dev_, gidx);
-  resmgr.copy(eqjacsp_selfidx_dev_, eqjacsp_selfidx);
+  resmgr.copy(eqjacsp_idx_dev_, eqjacsp_idx);
   if (opflow->include_powerimbalance_variables) {
     resmgr.copy(xidxpimb_dev_, xidxpimb);
     resmgr.copy(jacsp_idx_dev_, jacsp_idx);
@@ -111,7 +111,7 @@ int BUSParamsRajaHiop::copy(OPFLOW opflow) {
   xidx_dev_ = xidx;
   xidxpimb_dev_ = xidxpimb;
   gidx_dev_ = gidx;
-  eqjacsp_selfidx_dev_ = eqjacsp_selfidx;
+  eqjacsp_idx_dev_ = eqjacsp_idx;
   jacsp_idx_dev_ = jacsp_idx;
   jacsq_idx_dev_ = jacsq_idx;
   powerimbalance_penalty_dev_ = powerimbalance_penalty;
@@ -149,7 +149,7 @@ int BUSParamsRajaHiop::allocate(OPFLOW opflow) {
 
   xidx = paramAlloc<int>(h_allocator_, nbus);
   gidx = paramAlloc<int>(h_allocator_, nbus);
-  eqjacsp_selfidx = paramAlloc<int>(h_allocator_, 2 * nbus);
+  eqjacsp_idx = paramAlloc<int>(h_allocator_, 2 * nbus);
 
   if (opflow->include_powerimbalance_variables) {
     xidxpimb = paramAlloc<int>(h_allocator_, nbus);
@@ -237,7 +237,7 @@ int BUSParamsRajaHiop::allocate(OPFLOW opflow) {
 
   xidx_dev_ = paramAlloc<int>(d_allocator_, nbus);
   gidx_dev_ = paramAlloc<int>(d_allocator_, nbus);
-  eqjacsp_selfidx_dev_ = paramAlloc<int>(d_allocator_, 2 * nbus);
+  eqjacsp_idx_dev_ = paramAlloc<int>(d_allocator_, 2 * nbus);
 
   if (opflow->include_powerimbalance_variables) {
     xidxpimb_dev_ = paramAlloc<int>(d_allocator_, nbus);

--- a/src/opflow/model/power_bal_hiop/paramsrajahiop.cpp
+++ b/src/opflow/model/power_bal_hiop/paramsrajahiop.cpp
@@ -903,7 +903,7 @@ void PbpolModelRajaHiop::destroy(OPFLOW opflow) {
 
     h_allocator_.deallocate(i_jaceq);
     h_allocator_.deallocate(j_jaceq);
-    h_allocator_.deallocate(val_jaceq);
+    h_allocator_.deallocate(perm_jaceq);
 
     h_allocator_.deallocate(i_hess);
     h_allocator_.deallocate(j_hess);

--- a/src/opflow/model/power_bal_hiop/paramsrajahiop.h
+++ b/src/opflow/model/power_bal_hiop/paramsrajahiop.h
@@ -270,7 +270,8 @@ struct PbpolModelRajaHiop : public _p_FormPBPOLRAJAHIOP {
   PbpolModelRajaHiop(void) {
     i_jaceq = j_jaceq = i_jacineq = j_jacineq = NULL;
     i_hess = j_hess = NULL;
-    val_jaceq = val_jacineq = val_hess = NULL;
+    perm_jaceq = NULL;
+    val_jacineq = val_hess = NULL;
   }
 
   void destroy(OPFLOW opflow);
@@ -288,10 +289,10 @@ struct PbpolModelRajaHiop : public _p_FormPBPOLRAJAHIOP {
   // Arrays to store Jacobian and Hessian indices and entries on CPU (used with
   // GPU sparse model)
   int *i_jaceq,
-      *j_jaceq; // Row and column indices for equality constrained Jacobian
+      *j_jaceq; // Row and column indices for equality constraints Jacobian
   int *i_jacineq,
-      *j_jacineq; // Row and column indices for inequality constrained Jacobain
+      *j_jacineq; // Row and column indices for inequality constraints Jacobain
   int *i_hess, *j_hess; // Row and column indices for hessian
-  double *val_jaceq, *val_jacineq,
-      *val_hess; // values for equality, inequality jacobians and hessian
+  int *perm_jaceq; // Permutation for equality constraints Jacobian indices
+  double *val_jacineq, *val_hess; // values for inequality jacobians and hessian
 };

--- a/src/opflow/model/power_bal_hiop/paramsrajahiop.h
+++ b/src/opflow/model/power_bal_hiop/paramsrajahiop.h
@@ -270,7 +270,7 @@ struct PbpolModelRajaHiop : public _p_FormPBPOLRAJAHIOP {
   PbpolModelRajaHiop(void) {
     i_jaceq = j_jaceq = i_jacineq = j_jacineq = NULL;
     i_hess = j_hess = NULL;
-    perm_jaceq = NULL;
+    perm_jaceq = perm_jaceq_dev = NULL;
     val_jacineq = val_hess = NULL;
   }
 
@@ -293,6 +293,7 @@ struct PbpolModelRajaHiop : public _p_FormPBPOLRAJAHIOP {
   int *i_jacineq,
       *j_jacineq; // Row and column indices for inequality constraints Jacobain
   int *i_hess, *j_hess; // Row and column indices for hessian
-  int *perm_jaceq; // Permutation for equality constraints Jacobian indices
+  int *perm_jaceq, 
+      *perm_jaceq_dev; // Permutation for equality constraints Jacobian indices
   double *val_jacineq, *val_hess; // values for inequality jacobians and hessian
 };

--- a/src/opflow/model/power_bal_hiop/paramsrajahiop.h
+++ b/src/opflow/model/power_bal_hiop/paramsrajahiop.h
@@ -29,7 +29,7 @@ struct BUSParamsRajaHiop {
   int *jacsp_idx;  /* Location number in the sparse Jacobian for Pimb */
   int *jacsq_idx;  /* Location number in the sparse Jacobian for Qimb */
   int *hesssp_idx; /* KS: Hessian indices */
-  int *eqjacsp_selfidx; /* Flat-array position for bus self-admittance in eq
+  int *eqjacsp_idx; /* Flat-array position for bus self-admittance in eq
                            Jacobian. [2*i] = P-row base, [2*i+1] = Q-row base */
   int *ispv;            /* KS: ispv[i] = 1 if bus is PV bus */
   int *gineqidx;        /* KS: starting position of bus ineq constraints */
@@ -56,7 +56,7 @@ struct BUSParamsRajaHiop {
   int *jacsp_idx_dev_;  /* Location number in the sparse Jacobian for Pimb */
   int *jacsq_idx_dev_;  /* Location number in the sparse Jacobian for Qimb */
   int *hesssp_idx_dev_; /* Location number in the Hessian */
-  int *eqjacsp_selfidx_dev_; /* KS: eqjacsp_selfidx device counterpart */
+  int *eqjacsp_idx_dev_; /* KS: eqjacsp_idx device counterpart */
   int *ispv_dev_;            /* KS: dev counterpart of ispv */
   int *gineqidx_dev_;        /* KS: dev counterpart of gineqidx */
   int *ineqjacsp_idx_dev_;   /* KS: device counterpart of ineqjacsp_idx_ */

--- a/src/opflow/model/power_bal_hiop/paramsrajahiop.h
+++ b/src/opflow/model/power_bal_hiop/paramsrajahiop.h
@@ -29,13 +29,13 @@ struct BUSParamsRajaHiop {
   int *jacsp_idx;  /* Location number in the sparse Jacobian for Pimb */
   int *jacsq_idx;  /* Location number in the sparse Jacobian for Qimb */
   int *hesssp_idx; /* KS: Hessian indices */
-  int *eqjacsp_idx; /* Flat-array position for bus self-admittance in eq
-                           Jacobian. [2*i] = P-row base, [2*i+1] = Q-row base */
-  int *ispv;            /* KS: ispv[i] = 1 if bus is PV bus */
-  int *gineqidx;        /* KS: starting position of bus ineq constraints */
-  int *ineqjacsp_idx;   /* KS: index in flat sparse ineq Jacobian array */
-  int *genoffset;       /* KS: Offset into flattened gen array for this bus */
-  int *ngenONbus;       /* KS: Number of ON generators on this bus */
+  int *eqjacsp_idx;   /* Flat-array position for bus self-admittance in eq
+                             Jacobian. [2*i] = P-row base, [2*i+1] = Q-row base */
+  int *ispv;          /* KS: ispv[i] = 1 if bus is PV bus */
+  int *gineqidx;      /* KS: starting position of bus ineq constraints */
+  int *ineqjacsp_idx; /* KS: index in flat sparse ineq Jacobian array */
+  int *genoffset;     /* KS: Offset into flattened gen array for this bus */
+  int *ngenONbus;     /* KS: Number of ON generators on this bus */
 
   // Device data
   int *isref_dev_;      /* isref[i] = 1 if bus is reference bus */
@@ -53,15 +53,15 @@ struct BUSParamsRajaHiop {
                          X vector */
   int *gidx_dev_; /* starting locations for bus balance equations in constraint
                      vector */
-  int *jacsp_idx_dev_;  /* Location number in the sparse Jacobian for Pimb */
-  int *jacsq_idx_dev_;  /* Location number in the sparse Jacobian for Qimb */
-  int *hesssp_idx_dev_; /* Location number in the Hessian */
-  int *eqjacsp_idx_dev_; /* KS: eqjacsp_idx device counterpart */
-  int *ispv_dev_;            /* KS: dev counterpart of ispv */
-  int *gineqidx_dev_;        /* KS: dev counterpart of gineqidx */
-  int *ineqjacsp_idx_dev_;   /* KS: device counterpart of ineqjacsp_idx_ */
-  int *genoffset_dev_;       /* KS: dev counterpart of genoffset */
-  int *ngenONbus_dev_;       /* KS: dev counterpart of ngenONbus */
+  int *jacsp_idx_dev_;     /* Location number in the sparse Jacobian for Pimb */
+  int *jacsq_idx_dev_;     /* Location number in the sparse Jacobian for Qimb */
+  int *hesssp_idx_dev_;    /* Location number in the Hessian */
+  int *eqjacsp_idx_dev_;   /* KS: eqjacsp_idx device counterpart */
+  int *ispv_dev_;          /* KS: dev counterpart of ispv */
+  int *gineqidx_dev_;      /* KS: dev counterpart of gineqidx */
+  int *ineqjacsp_idx_dev_; /* KS: device counterpart of ineqjacsp_idx_ */
+  int *genoffset_dev_;     /* KS: dev counterpart of genoffset */
+  int *ngenONbus_dev_;     /* KS: dev counterpart of ngenONbus */
 
   int allocate(OPFLOW);
   int destroy(OPFLOW);
@@ -293,7 +293,7 @@ struct PbpolModelRajaHiop : public _p_FormPBPOLRAJAHIOP {
   int *i_jacineq,
       *j_jacineq; // Row and column indices for inequality constraints Jacobain
   int *i_hess, *j_hess; // Row and column indices for hessian
-  int *perm_jaceq, 
+  int *perm_jaceq,
       *perm_jaceq_dev; // Permutation for equality constraints Jacobian indices
   double *val_jacineq, *val_hess; // values for inequality jacobians and hessian
 };

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse.cpp
@@ -280,11 +280,11 @@ PetscErrorCode OPFLOWModelSetUp_PBPOLRAJAHIOPSPARSE(OPFLOW opflow) {
     for (int ibus = 0; ibus < ps->nbus; ++ibus) {
       PSBUS bus_eq = &(ps->bus[ibus]);
 
-      busparams->eqjacsp_selfidx[2 * ibus] = nnz_eqjacsp;
+      busparams->eqjacsp_idx[2 * ibus] = nnz_eqjacsp;
       nnz_eqjacsp += 2;
 
       if (bus_eq->ide == ISOLATED_BUS) {
-        busparams->eqjacsp_selfidx[2 * ibus + 1] = nnz_eqjacsp;
+        busparams->eqjacsp_idx[2 * ibus + 1] = nnz_eqjacsp;
         nnz_eqjacsp += 2;
         continue;
       }
@@ -316,7 +316,7 @@ PetscErrorCode OPFLOWModelSetUp_PBPOLRAJAHIOPSPARSE(OPFLOW opflow) {
         }
       }
 
-      busparams->eqjacsp_selfidx[2 * ibus + 1] = nnz_eqjacsp;
+      busparams->eqjacsp_idx[2 * ibus + 1] = nnz_eqjacsp;
       nnz_eqjacsp += 2;
 
       if (opflow->include_powerimbalance_variables) {
@@ -364,13 +364,13 @@ PetscErrorCode OPFLOWModelSetUp_PBPOLRAJAHIOPSPARSE(OPFLOW opflow) {
         int busidxt = (int)(connbuses_eq[1] - ps->bus);
 
         lineparams->eqjacsp_diag_idx[4 * linei_eq + 0] =
-            busparams->eqjacsp_selfidx[2 * busidxf];
+            busparams->eqjacsp_idx[2 * busidxf];
         lineparams->eqjacsp_diag_idx[4 * linei_eq + 1] =
-            busparams->eqjacsp_selfidx[2 * busidxf + 1];
+            busparams->eqjacsp_idx[2 * busidxf + 1];
         lineparams->eqjacsp_diag_idx[4 * linei_eq + 2] =
-            busparams->eqjacsp_selfidx[2 * busidxt];
+            busparams->eqjacsp_idx[2 * busidxt];
         lineparams->eqjacsp_diag_idx[4 * linei_eq + 3] =
-            busparams->eqjacsp_selfidx[2 * busidxt + 1];
+            busparams->eqjacsp_idx[2 * busidxt + 1];
 
         auto key = std::make_pair(std::min(busidxf, busidxt),
                                   std::max(busidxf, busidxt));

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse.cpp
@@ -513,20 +513,6 @@ extern PetscErrorCode OPFLOWSolutionCallback_PBPOLRAJAHIOPSPARSE(
     const double *, double);
 
 /**
- * Empty stub for the equality constraint Jacobian in the RAJA sparse model.
- * Can be deleted if needed (dead code).
- */
-PetscErrorCode
-OPFLOWComputeEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
-                                                            Vec X, Mat Je) {
-  (void)opflow;
-  (void)X;
-  (void)Je;
-  PetscFunctionBegin;
-  PetscFunctionReturn(0);
-}
-
-/**
  * @brief Constructor for the PBPOLRAJAHIOPSPARSE model.
  *
  * This function creates a new PBPOLRAJAHIOPSPARSE model and sets pointers
@@ -579,7 +565,7 @@ PetscErrorCode OPFLOWModelCreate_PBPOLRAJAHIOPSPARSE(OPFLOW opflow) {
   opflow->modelops.solutiontops = OPFLOWSolutionToPS_PBPOLRAJAHIOPSPARSE;
   opflow->modelops.setup = OPFLOWModelSetUp_PBPOLRAJAHIOPSPARSE;
   opflow->modelops.computeequalityconstraintjacobian =
-      OPFLOWComputeEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE;
+      OPFLOWComputeEqualityConstraintJacobian_PBPOL;
   opflow->modelops.computesparseequalityconstraintjacobianhiop =
       OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE;
   opflow->modelops.computeinequalityconstraintjacobian =

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse_gpu.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse_gpu.cpp
@@ -264,13 +264,13 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
     int *b_xidx = busparams->xidx_dev_;
     double *b_gl = busparams->gl_dev_;
     double *b_bl = busparams->bl_dev_;
-    int *b_selfidx = busparams->eqjacsp_selfidx_dev_;
+    int *b_idx = busparams->eqjacsp_idx_dev_;
 
     RAJA::forall<exago_raja_exec>(
         RAJA::RangeSegment(0, busparams->nbus),
         RAJA_LAMBDA(RAJA::Index_type i) {
-          int pbase = b_selfidx[2 * i];
-          int qbase = b_selfidx[2 * i + 1];
+          int pbase = b_idx[2 * i];
+          int qbase = b_idx[2 * i + 1];
 
           if (b_isisolated[i]) {
             jace_dev[pbase + 0] = 1.0;

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse_gpu.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse_gpu.cpp
@@ -392,10 +392,12 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
 
           RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[pfbase + 0]],
                                              dPf_dthetaf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[pfbase + 1]], dPf_dVmf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[pfbase + 1]],
+                                             dPf_dVmf);
           RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qfbase + 0]],
                                              dQf_dthetaf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qfbase + 1]], dQf_dVmf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qfbase + 1]],
+                                             dQf_dVmf);
 
           /* From-bus off-diagonal */
           double dPf_dthetat = Vmf * Vmt * (Gft * sin_ft - Bft * cos_ft);
@@ -404,10 +406,14 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
           double dQf_dVmt = Vmf * (-Bft * cos_ft + Gft * sin_ft);
 
           int obase = l_eqjacsp_idx[l];
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 0]], dPf_dthetat);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 1]], dPf_dVmt);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 2]], dQf_dthetat);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 3]], dQf_dVmt);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 0]],
+                                             dPf_dthetat);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 1]],
+                                             dPf_dVmt);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 2]],
+                                             dQf_dthetat);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 3]],
+                                             dQf_dVmt);
 
           /* To-bus diagonal */
           double dPt_dthetat = Vmt * Vmf * (-Gtf * sin_tf + Btf * cos_tf);
@@ -422,10 +428,12 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
 
           RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[ptbase + 0]],
                                              dPt_dthetat);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[ptbase + 1]], dPt_dVmt);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[ptbase + 1]],
+                                             dPt_dVmt);
           RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qtbase + 0]],
                                              dQt_dthetat);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qtbase + 1]], dQt_dVmt);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qtbase + 1]],
+                                             dQt_dVmt);
 
           /* To-bus off-diagonal */
           double dPt_dthetaf = Vmt * Vmf * (Gtf * sin_tf - Btf * cos_tf);
@@ -433,10 +441,14 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
           double dQt_dthetaf = Vmt * Vmf * (-Btf * sin_tf - Gtf * cos_tf);
           double dQt_dVmf = Vmt * (-Btf * cos_tf + Gtf * sin_tf);
 
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 4]], dPt_dthetaf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 5]], dPt_dVmf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 6]], dQt_dthetaf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 7]], dQt_dVmf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 4]],
+                                             dPt_dthetaf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 5]],
+                                             dPt_dVmf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 6]],
+                                             dQt_dthetaf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 7]],
+                                             dQt_dVmf);
         });
   }
 }

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse_gpu.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse_gpu.cpp
@@ -242,6 +242,7 @@ void ComputeIneqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
 
 void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
                                                const double *x_dev,
+                                               const int *perm_dev,
                                                double *jace_dev) {
   PbpolModelRajaHiop *pbpolrajahiopsparse =
       reinterpret_cast<PbpolModelRajaHiop *>(opflow->model);
@@ -273,19 +274,19 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
           int qbase = b_idx[2 * i + 1];
 
           if (b_isisolated[i]) {
-            jace_dev[pbase + 0] = 1.0;
-            jace_dev[pbase + 1] = 0.0;
-            jace_dev[qbase + 0] = 0.0;
-            jace_dev[qbase + 1] = 1.0;
+            jace_dev[perm_dev[pbase + 0]] = 1.0;
+            jace_dev[perm_dev[pbase + 1]] = 0.0;
+            jace_dev[perm_dev[qbase + 0]] = 0.0;
+            jace_dev[perm_dev[qbase + 1]] = 1.0;
             return;
           }
 
           double Vm = x_dev[b_xidx[i] + 1];
 
-          jace_dev[pbase + 0] = 0.0;
-          jace_dev[pbase + 1] = 2.0 * Vm * b_gl[i];
-          jace_dev[qbase + 0] = 0.0;
-          jace_dev[qbase + 1] = -2.0 * Vm * b_bl[i];
+          jace_dev[perm_dev[pbase + 0]] = 0.0;
+          jace_dev[perm_dev[pbase + 1]] = 2.0 * Vm * b_gl[i];
+          jace_dev[perm_dev[qbase + 0]] = 0.0;
+          jace_dev[perm_dev[qbase + 1]] = -2.0 * Vm * b_bl[i];
         });
 
     if (opflow->include_powerimbalance_variables) {
@@ -294,10 +295,10 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
       RAJA::forall<exago_raja_exec>(
           RAJA::RangeSegment(0, busparams->nbus),
           RAJA_LAMBDA(RAJA::Index_type i) {
-            jace_dev[b_jacsp[i]] = 1.0;
-            jace_dev[b_jacsp[i] + 1] = -1.0;
-            jace_dev[b_jacsq[i]] = 1.0;
-            jace_dev[b_jacsq[i] + 1] = -1.0;
+            jace_dev[perm_dev[b_jacsp[i]]] = 1.0;
+            jace_dev[perm_dev[b_jacsp[i]] + 1] = -1.0;
+            jace_dev[perm_dev[b_jacsq[i]]] = 1.0;
+            jace_dev[perm_dev[b_jacsq[i]] + 1] = -1.0;
           });
     }
 
@@ -306,8 +307,8 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
     RAJA::forall<exago_raja_exec>(
         RAJA::RangeSegment(0, genparams->ngenON),
         RAJA_LAMBDA(RAJA::Index_type i) {
-          jace_dev[g_eqjacspbus[i]] = -1.0;
-          jace_dev[g_eqjacsqbus[i]] = -1.0;
+          jace_dev[perm_dev[g_eqjacspbus[i]]] = -1.0;
+          jace_dev[perm_dev[g_eqjacsqbus[i]]] = -1.0;
         });
 
     if (opflow->include_loadloss_variables) {
@@ -316,8 +317,8 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
       RAJA::forall<exago_raja_exec>(
           RAJA::RangeSegment(0, loadparams->nload),
           RAJA_LAMBDA(RAJA::Index_type i) {
-            jace_dev[l_jacsp[i]] = -1.0;
-            jace_dev[l_jacsq[i]] = -1.0;
+            jace_dev[perm_dev[l_jacsp[i]]] = -1.0;
+            jace_dev[perm_dev[l_jacsq[i]]] = -1.0;
           });
     }
 
@@ -330,10 +331,10 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
             if (g_isrenewable[i])
               return;
             int base = g_eqjacspgen[i];
-            jace_dev[base + 0] = -1.0;
-            jace_dev[base + 1] = 1.0;
-            jace_dev[base + 2] = 1.0;
-            jace_dev[base + 3] = 1.0;
+            jace_dev[perm_dev[base + 0]] = -1.0;
+            jace_dev[perm_dev[base + 1]] = 1.0;
+            jace_dev[perm_dev[base + 2]] = 1.0;
+            jace_dev[perm_dev[base + 3]] = 1.0;
           });
     }
   }
@@ -389,12 +390,12 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
           int pfbase = l_eqjacsp_diag[4 * l + 0];
           int qfbase = l_eqjacsp_diag[4 * l + 1];
 
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[pfbase + 0],
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[pfbase + 0]],
                                              dPf_dthetaf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[pfbase + 1], dPf_dVmf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[qfbase + 0],
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[pfbase + 1]], dPf_dVmf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qfbase + 0]],
                                              dQf_dthetaf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[qfbase + 1], dQf_dVmf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qfbase + 1]], dQf_dVmf);
 
           /* From-bus off-diagonal */
           double dPf_dthetat = Vmf * Vmt * (Gft * sin_ft - Bft * cos_ft);
@@ -403,10 +404,10 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
           double dQf_dVmt = Vmf * (-Bft * cos_ft + Gft * sin_ft);
 
           int obase = l_eqjacsp_idx[l];
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[obase + 0], dPf_dthetat);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[obase + 1], dPf_dVmt);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[obase + 2], dQf_dthetat);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[obase + 3], dQf_dVmt);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 0]], dPf_dthetat);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 1]], dPf_dVmt);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 2]], dQf_dthetat);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 3]], dQf_dVmt);
 
           /* To-bus diagonal */
           double dPt_dthetat = Vmt * Vmf * (-Gtf * sin_tf + Btf * cos_tf);
@@ -419,12 +420,12 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
           int ptbase = l_eqjacsp_diag[4 * l + 2];
           int qtbase = l_eqjacsp_diag[4 * l + 3];
 
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[ptbase + 0],
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[ptbase + 0]],
                                              dPt_dthetat);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[ptbase + 1], dPt_dVmt);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[qtbase + 0],
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[ptbase + 1]], dPt_dVmt);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qtbase + 0]],
                                              dQt_dthetat);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[qtbase + 1], dQt_dVmt);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[qtbase + 1]], dQt_dVmt);
 
           /* To-bus off-diagonal */
           double dPt_dthetaf = Vmt * Vmf * (Gtf * sin_tf - Btf * cos_tf);
@@ -432,10 +433,10 @@ void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
           double dQt_dthetaf = Vmt * Vmf * (-Btf * sin_tf - Gtf * cos_tf);
           double dQt_dVmf = Vmt * (-Btf * cos_tf + Gtf * sin_tf);
 
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[obase + 4], dPt_dthetaf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[obase + 5], dPt_dVmf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[obase + 6], dQt_dthetaf);
-          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[obase + 7], dQt_dVmf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 4]], dPt_dthetaf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 5]], dPt_dVmf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 6]], dQt_dthetaf);
+          RAJA::atomicAdd<RAJA::auto_atomic>(&jace_dev[perm_dev[obase + 7]], dQt_dVmf);
         });
   }
 }

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse_gpu.hpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparse_gpu.hpp
@@ -31,6 +31,7 @@ void ComputeIneqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
  */
 void ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(OPFLOW opflow,
                                                const double *x_dev,
+                                               const int *perm_dev,
                                                double *jace_dev);
 
 #endif // EXAGO_ENABLE_HIOP_SPARSE

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
@@ -907,6 +907,12 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     // Copy indices from host to device
     resmgr.copy(iJacS_dev, pbpolrajahiopsparse->i_jaceq);
     resmgr.copy(jJacS_dev, pbpolrajahiopsparse->j_jaceq);
+
+    // Allocate permutation on device and copy from host
+    umpire::Allocator d_allocator_ = resmgr.getAllocator("DEVICE");
+    pbpolrajahiopsparse->perm_jaceq_dev =
+        (int *)(d_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
+    resmgr.copy(pbpolrajahiopsparse->perm_jaceq_dev, pbpolrajahiopsparse->perm_jaceq);
   }
 
   if (MJacS_dev != NULL) {
@@ -916,7 +922,7 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     /* KS: Compute equality constraint Jacobian directly on device.
        No H2D, D2H copies: x_dev is already on device, output goes
        straight into MJacS_dev. */
-    ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(opflow, x_dev, MJacS_dev);
+    ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(opflow, x_dev, pbpolrajahiopsparse->perm_jaceq_dev, MJacS_dev);
 
     ierr = PetscLogEventEnd(opflow->eqconsjaclogger, 0, 0, 0, 0);
     CHKERRQ(ierr);

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
@@ -899,7 +899,8 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     for (int i = 0; i < opflow->nnz_eqjacsp; i++) {
       iRow[i] = iRow_temp[perm_temp[i]];
       jCol[i] = jCol_temp[perm_temp[i]];
-      perm[i] = perm_temp[i];
+      perm[perm_temp[i]] = i; // reverse map to store values directly in the
+                              // desired location
     } 
     h_allocator_.deallocate(iRow_temp);
     h_allocator_.deallocate(jCol_temp);

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
@@ -574,7 +574,6 @@ OPFLOWComputeSparseInequalityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
   PbpolModelRajaHiop *pbpolrajahiopsparse =
       reinterpret_cast<PbpolModelRajaHiop *>(opflow->model);
   PetscErrorCode ierr;
-  double *x, *values;
   PetscInt *iRowstart, *jColstart;
   PetscInt roffset, coffset;
   PetscInt nrow, ncol;
@@ -686,14 +685,7 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
   PbpolModelRajaHiop *pbpolrajahiopsparse =
       reinterpret_cast<PbpolModelRajaHiop *>(opflow->model);
   PetscErrorCode ierr;
-  PetscInt *iRowstart, *jColstart;
-  PetscScalar *x, *values;
   PetscInt roffset, coffset;
-  PetscInt nrow, ncol;
-  PetscInt nvals;
-  const PetscInt *cols;
-  const PetscScalar *vals;
-  PetscInt i, j;
   auto &resmgr = umpire::ResourceManager::getInstance();
 
   PetscFunctionBegin;
@@ -702,9 +694,8 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
   // This only needs to be done once since the sparsity pattern of the Jacobian
   // does not change during the optimization.
   if (iJacS_dev != NULL && jJacS_dev != NULL) {
-    /* Compute sparsity pattern on host, matching the flat-array layout
-       defined during setup in OPFLOWModelSetUp_PBPOLRAJAHIOPSPARSE.
-*/
+    // Compute sparsity pattern on host, matching the flat-array layout
+    // defined during setup in OPFLOWModelSetUp_PBPOLRAJAHIOPSPARSE.
     roffset = 0;
     coffset = 0;
 
@@ -727,7 +718,7 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     LINEParamsRajaHiop *lineparams = &pbpolrajahiopsparse->lineparams;
 
     int geni = 0, loadi = 0;
-    /*KS: not worth movint this to the gpu */
+    /*KS: not worth moving this to the gpu */
     for (int ibus = 0; ibus < ps->nbus; ibus++) {
       PSBUS bus = &ps->bus[ibus];
       int P_row = roffset + busparams->gidx[ibus];

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
@@ -730,7 +730,7 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
       int base;
 
       /* P-row self-admittance */
-      base = busparams->eqjacsp_selfidx[2 * ibus];
+      base = busparams->eqjacsp_idx[2 * ibus];
       iRow_temp[base] = P_row;
       jCol_temp[base] = theta_col;
       iRow_temp[base + 1] = P_row;
@@ -738,7 +738,7 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
 
       if (bus->ide == ISOLATED_BUS) {
         /* Q-row self-admittance for isolated bus */
-        base = busparams->eqjacsp_selfidx[2 * ibus + 1];
+        base = busparams->eqjacsp_idx[2 * ibus + 1];
         iRow_temp[base] = Q_row;
         jCol_temp[base] = theta_col;
         iRow_temp[base + 1] = Q_row;
@@ -779,7 +779,7 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
       }
 
       /* Q-row self-admittance */
-      base = busparams->eqjacsp_selfidx[2 * ibus + 1];
+      base = busparams->eqjacsp_idx[2 * ibus + 1];
       iRow_temp[base] = Q_row;
       jCol_temp[base] = theta_col;
       iRow_temp[base + 1] = Q_row;

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
@@ -709,6 +709,8 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
         (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
     pbpolrajahiopsparse->j_jaceq =
         (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
+    pbpolrajahiopsparse->perm_jaceq =
+        (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
 
     int *iRow_temp = (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
     int *jCol_temp = (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
@@ -882,10 +884,10 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     }
 
     // Sort and permute indices
-    std::vector<int> ind_temp(opflow->nnz_eqjacsp);
-    std::iota(ind_temp.begin(), ind_temp.end(), 0);
-    std::sort(ind_temp.begin(), 
-              ind_temp.end(), 
+    std::vector<int> perm_temp(opflow->nnz_eqjacsp);
+    std::iota(perm_temp.begin(), perm_temp.end(), 0);
+    std::sort(perm_temp.begin(), 
+              perm_temp.end(), 
               [&](int i, int j) {
                 return (iRow_temp[i] != iRow_temp[j]) ? 
                         iRow_temp[i] < iRow_temp[j] : jCol_temp[i] < jCol_temp[j];
@@ -893,9 +895,11 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
 
     int *iRow = pbpolrajahiopsparse->i_jaceq;
     int *jCol = pbpolrajahiopsparse->j_jaceq;
+    int *perm = pbpolrajahiopsparse->perm_jaceq;
     for (int i = 0; i < opflow->nnz_eqjacsp; i++) {
-      iRow[i] = iRow_temp[ind_temp[i]];
-      jCol[i] = jCol_temp[ind_temp[i]];
+      iRow[i] = iRow_temp[perm_temp[i]];
+      jCol[i] = jCol_temp[perm_temp[i]];
+      perm[i] = perm_temp[i];
     } 
     h_allocator_.deallocate(iRow_temp);
     h_allocator_.deallocate(jCol_temp);
@@ -903,7 +907,6 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     // Copy indices from host to device
     resmgr.copy(iJacS_dev, pbpolrajahiopsparse->i_jaceq);
     resmgr.copy(jJacS_dev, pbpolrajahiopsparse->j_jaceq);
-    std::abort();
   }
 
   if (MJacS_dev != NULL) {

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
@@ -712,8 +712,10 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     pbpolrajahiopsparse->perm_jaceq =
         (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
 
-    int *iRow_temp = (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
-    int *jCol_temp = (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
+    int *iRow_temp =
+        (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
+    int *jCol_temp =
+        (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
 
     PS ps = opflow->ps;
     BUSParamsRajaHiop *busparams = &pbpolrajahiopsparse->busparams;
@@ -886,12 +888,10 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     // Sort and permute indices
     std::vector<int> perm_temp(opflow->nnz_eqjacsp);
     std::iota(perm_temp.begin(), perm_temp.end(), 0);
-    std::sort(perm_temp.begin(), 
-              perm_temp.end(), 
-              [&](int i, int j) {
-                return (iRow_temp[i] != iRow_temp[j]) ? 
-                        iRow_temp[i] < iRow_temp[j] : jCol_temp[i] < jCol_temp[j];
-              });
+    std::sort(perm_temp.begin(), perm_temp.end(), [&](int i, int j) {
+      return (iRow_temp[i] != iRow_temp[j]) ? iRow_temp[i] < iRow_temp[j]
+                                            : jCol_temp[i] < jCol_temp[j];
+    });
 
     int *iRow = pbpolrajahiopsparse->i_jaceq;
     int *jCol = pbpolrajahiopsparse->j_jaceq;
@@ -901,7 +901,7 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
       jCol[i] = jCol_temp[perm_temp[i]];
       perm[perm_temp[i]] = i; // reverse map to store values directly in the
                               // desired location
-    } 
+    }
     h_allocator_.deallocate(iRow_temp);
     h_allocator_.deallocate(jCol_temp);
 
@@ -913,7 +913,8 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     umpire::Allocator d_allocator_ = resmgr.getAllocator("DEVICE");
     pbpolrajahiopsparse->perm_jaceq_dev =
         (int *)(d_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
-    resmgr.copy(pbpolrajahiopsparse->perm_jaceq_dev, pbpolrajahiopsparse->perm_jaceq);
+    resmgr.copy(pbpolrajahiopsparse->perm_jaceq_dev,
+                pbpolrajahiopsparse->perm_jaceq);
   }
 
   if (MJacS_dev != NULL) {
@@ -923,7 +924,8 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
     /* KS: Compute equality constraint Jacobian directly on device.
        No H2D, D2H copies: x_dev is already on device, output goes
        straight into MJacS_dev. */
-    ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(opflow, x_dev, pbpolrajahiopsparse->perm_jaceq_dev, MJacS_dev);
+    ComputeEqJacValuesGPU_PBPOLRAJAHIOPSPARSE(
+        opflow, x_dev, pbpolrajahiopsparse->perm_jaceq_dev, MJacS_dev);
 
     ierr = PetscLogEventEnd(opflow->eqconsjaclogger, 0, 0, 0, 0);
     CHKERRQ(ierr);

--- a/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
+++ b/src/opflow/model/power_bal_hiop/pbpolrajahiopsparsekernels.cpp
@@ -16,6 +16,10 @@
 #include "pbpolrajahiopsparse.hpp"
 #include "pbpolrajahiopsparse_gpu.hpp"
 
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
 /**
  * @brief Set the initial guess array for the PBPOLRAJAHIOPSPARSE model.
  *
@@ -705,11 +709,9 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
         (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
     pbpolrajahiopsparse->j_jaceq =
         (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
-    pbpolrajahiopsparse->val_jaceq =
-        (double *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(double)));
 
-    int *iRow = pbpolrajahiopsparse->i_jaceq;
-    int *jCol = pbpolrajahiopsparse->j_jaceq;
+    int *iRow_temp = (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
+    int *jCol_temp = (int *)(h_allocator_.allocate(opflow->nnz_eqjacsp * sizeof(int)));
 
     PS ps = opflow->ps;
     BUSParamsRajaHiop *busparams = &pbpolrajahiopsparse->busparams;
@@ -729,18 +731,18 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
 
       /* P-row self-admittance */
       base = busparams->eqjacsp_selfidx[2 * ibus];
-      iRow[base] = P_row;
-      jCol[base] = theta_col;
-      iRow[base + 1] = P_row;
-      jCol[base + 1] = Vm_col;
+      iRow_temp[base] = P_row;
+      jCol_temp[base] = theta_col;
+      iRow_temp[base + 1] = P_row;
+      jCol_temp[base + 1] = Vm_col;
 
       if (bus->ide == ISOLATED_BUS) {
         /* Q-row self-admittance for isolated bus */
         base = busparams->eqjacsp_selfidx[2 * ibus + 1];
-        iRow[base] = Q_row;
-        jCol[base] = theta_col;
-        iRow[base + 1] = Q_row;
-        jCol[base + 1] = Vm_col;
+        iRow_temp[base] = Q_row;
+        jCol_temp[base] = theta_col;
+        iRow_temp[base + 1] = Q_row;
+        jCol_temp[base + 1] = Vm_col;
         continue;
       }
 
@@ -748,10 +750,10 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
       if (opflow->include_powerimbalance_variables) {
         base = busparams->jacsp_idx[ibus];
         int pimb_col = coffset + busparams->xidxpimb[ibus];
-        iRow[base] = P_row;
-        jCol[base] = pimb_col;
-        iRow[base + 1] = P_row;
-        jCol[base + 1] = pimb_col + 1;
+        iRow_temp[base] = P_row;
+        jCol_temp[base] = pimb_col;
+        iRow_temp[base + 1] = P_row;
+        jCol_temp[base + 1] = pimb_col + 1;
       }
 
       /* P-row gen Pg */
@@ -762,8 +764,8 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
         if (!gen->status)
           continue;
         base = genparams->eqjacspbus_idx[geni + gi];
-        iRow[base] = P_row;
-        jCol[base] = coffset + genparams->xidx[geni + gi];
+        iRow_temp[base] = P_row;
+        jCol_temp[base] = coffset + genparams->xidx[geni + gi];
         gi++;
       }
 
@@ -771,26 +773,26 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
       if (opflow->include_loadloss_variables) {
         for (int k = 0; k < bus->nload; k++) {
           base = loadparams->jacsp_idx[loadi + k];
-          iRow[base] = P_row;
-          jCol[base] = coffset + loadparams->xidx[loadi + k];
+          iRow_temp[base] = P_row;
+          jCol_temp[base] = coffset + loadparams->xidx[loadi + k];
         }
       }
 
       /* Q-row self-admittance */
       base = busparams->eqjacsp_selfidx[2 * ibus + 1];
-      iRow[base] = Q_row;
-      jCol[base] = theta_col;
-      iRow[base + 1] = Q_row;
-      jCol[base + 1] = Vm_col;
+      iRow_temp[base] = Q_row;
+      jCol_temp[base] = theta_col;
+      iRow_temp[base + 1] = Q_row;
+      jCol_temp[base + 1] = Vm_col;
 
       /* Q-row power imbalance */
       if (opflow->include_powerimbalance_variables) {
         base = busparams->jacsq_idx[ibus];
         int pimb_col = coffset + busparams->xidxpimb[ibus];
-        iRow[base] = Q_row;
-        jCol[base] = pimb_col + 2;
-        iRow[base + 1] = Q_row;
-        jCol[base + 1] = pimb_col + 3;
+        iRow_temp[base] = Q_row;
+        jCol_temp[base] = pimb_col + 2;
+        iRow_temp[base + 1] = Q_row;
+        jCol_temp[base + 1] = pimb_col + 3;
       }
 
       /* Q-row gen Qg */
@@ -801,8 +803,8 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
         if (!gen->status)
           continue;
         base = genparams->eqjacsqbus_idx[geni + gi];
-        iRow[base] = Q_row;
-        jCol[base] = coffset + genparams->xidx[geni + gi] + 1;
+        iRow_temp[base] = Q_row;
+        jCol_temp[base] = coffset + genparams->xidx[geni + gi] + 1;
         gi++;
       }
 
@@ -810,8 +812,8 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
       if (opflow->include_loadloss_variables) {
         for (int k = 0; k < bus->nload; k++) {
           base = loadparams->jacsq_idx[loadi + k];
-          iRow[base] = Q_row;
-          jCol[base] = coffset + loadparams->xidx[loadi + k] + 1;
+          iRow_temp[base] = Q_row;
+          jCol_temp[base] = coffset + loadparams->xidx[loadi + k] + 1;
         }
       }
 
@@ -835,25 +837,25 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
       int Vmf_col = thetaf_col + 1;
 
       /* From-bus off-diagonal: Pf w.r.t. thetat, Vmt */
-      iRow[base + 0] = Pf_row;
-      jCol[base + 0] = thetat_col;
-      iRow[base + 1] = Pf_row;
-      jCol[base + 1] = Vmt_col;
+      iRow_temp[base + 0] = Pf_row;
+      jCol_temp[base + 0] = thetat_col;
+      iRow_temp[base + 1] = Pf_row;
+      jCol_temp[base + 1] = Vmt_col;
       /* Qf w.r.t. thetat, Vmt */
-      iRow[base + 2] = Qf_row;
-      jCol[base + 2] = thetat_col;
-      iRow[base + 3] = Qf_row;
-      jCol[base + 3] = Vmt_col;
+      iRow_temp[base + 2] = Qf_row;
+      jCol_temp[base + 2] = thetat_col;
+      iRow_temp[base + 3] = Qf_row;
+      jCol_temp[base + 3] = Vmt_col;
       /* To-bus off-diagonal: Pt w.r.t. thetaf, Vmf */
-      iRow[base + 4] = Pt_row;
-      jCol[base + 4] = thetaf_col;
-      iRow[base + 5] = Pt_row;
-      jCol[base + 5] = Vmf_col;
+      iRow_temp[base + 4] = Pt_row;
+      jCol_temp[base + 4] = thetaf_col;
+      iRow_temp[base + 5] = Pt_row;
+      jCol_temp[base + 5] = Vmf_col;
       /* Qt w.r.t. thetaf, Vmf */
-      iRow[base + 6] = Qt_row;
-      jCol[base + 6] = thetaf_col;
-      iRow[base + 7] = Qt_row;
-      jCol[base + 7] = Vmf_col;
+      iRow_temp[base + 6] = Qt_row;
+      jCol_temp[base + 6] = thetaf_col;
+      iRow_temp[base + 7] = Qt_row;
+      jCol_temp[base + 7] = Vmf_col;
     }
 
     /* Generator set-point equality constraint entries */
@@ -868,19 +870,40 @@ OPFLOWComputeSparseEqualityConstraintJacobian_PBPOLRAJAHIOPSPARSE(
         int delPg_col = coffset + genparams->xpdevidx[g];
         int Pset_col = coffset + genparams->xpsetidx[g];
 
-        iRow[base + 0] = row0;
-        jCol[base + 0] = Pg_col;
-        iRow[base + 1] = row0;
-        jCol[base + 1] = delPg_col;
-        iRow[base + 2] = row0;
-        jCol[base + 2] = Pset_col;
-        iRow[base + 3] = row1;
-        jCol[base + 3] = Pset_col;
+        iRow_temp[base + 0] = row0;
+        jCol_temp[base + 0] = Pg_col;
+        iRow_temp[base + 1] = row0;
+        jCol_temp[base + 1] = delPg_col;
+        iRow_temp[base + 2] = row0;
+        jCol_temp[base + 2] = Pset_col;
+        iRow_temp[base + 3] = row1;
+        jCol_temp[base + 3] = Pset_col;
       }
     }
 
+    // Sort and permute indices
+    std::vector<int> ind_temp(opflow->nnz_eqjacsp);
+    std::iota(ind_temp.begin(), ind_temp.end(), 0);
+    std::sort(ind_temp.begin(), 
+              ind_temp.end(), 
+              [&](int i, int j) {
+                return (iRow_temp[i] != iRow_temp[j]) ? 
+                        iRow_temp[i] < iRow_temp[j] : jCol_temp[i] < jCol_temp[j];
+              });
+
+    int *iRow = pbpolrajahiopsparse->i_jaceq;
+    int *jCol = pbpolrajahiopsparse->j_jaceq;
+    for (int i = 0; i < opflow->nnz_eqjacsp; i++) {
+      iRow[i] = iRow_temp[ind_temp[i]];
+      jCol[i] = jCol_temp[ind_temp[i]];
+    } 
+    h_allocator_.deallocate(iRow_temp);
+    h_allocator_.deallocate(jCol_temp);
+
+    // Copy indices from host to device
     resmgr.copy(iJacS_dev, pbpolrajahiopsparse->i_jaceq);
     resmgr.copy(jJacS_dev, pbpolrajahiopsparse->j_jaceq);
+    std::abort();
   }
 
   if (MJacS_dev != NULL) {


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [x] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [x] Header files
- [x] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

As discussed in the comments to #48, the equality constraints Jacobian for hiopsparse_gpu were not ordered after the bypassing of PETSc functions. The proposed solution is to sort the indices after they are computed, and to store the permutation, so it can be re-used when computing the values.

The whole thing could still use some cleanup, but the `FUNCTIONALITY_TEST_OPFLOW_RAJAHIOP_SPARSE_GPU_TOML_TESTSUITE` now passes on the CUDA backend. Previously passing tests still pass on both CUDA and HIP backends.

... plus minor cleanup.