### PR TITLE
Spack updates after 2.0 release

### DIFF
--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -99,13 +99,13 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - exago@develop+mpi~ipopt+hiop~python~raja ^openmpi ^hiop~raja~sparse
-          - exago@develop+mpi~ipopt+hiop+python~raja ^openmpi ^hiop~raja~sparse
-          - exago@develop+mpi~ipopt+hiop~python+raja ^openmpi ^hiop+raja~sparse
-          - exago@develop+mpi+ipopt+hiop~python+raja ^openmpi ^hiop+raja~sparse
-          - exago@develop+mpi+ipopt+hiop+python+raja ^openmpi ^hiop+raja~sparse
-          - exago@develop+mpi+ipopt+hiop+python~raja ^openmpi ^hiop~raja~sparse
-          - exago@develop+mpi+ipopt~hiop+python~raja ^openmpi
+          - exago@2.0.0+mpi~ipopt+hiop~python~raja ^openmpi ^hiop~raja~sparse
+          - exago@2.0.0+mpi~ipopt+hiop+python~raja ^openmpi ^hiop~raja~sparse
+          - exago@2.0.0+mpi~ipopt+hiop~python+raja ^openmpi ^hiop+raja~sparse
+          - exago@2.0.0+mpi+ipopt+hiop~python+raja ^openmpi ^hiop+raja~sparse
+          - exago@2.0.0+mpi+ipopt+hiop+python+raja ^openmpi ^hiop+raja~sparse
+          - exago@2.0.0+mpi+ipopt+hiop+python~raja ^openmpi ^hiop~raja~sparse
+          - exago@2.0.0+mpi+ipopt~hiop+python~raja ^openmpi
 
     name: Build ExaGO with Spack
     steps:
@@ -161,8 +161,8 @@ jobs:
       - name: Spack local repo
         run: spack -e . repo add buildsystem/spack/spack_repo/exago
 
-      - name: Spack develop exago
-        run: spack -e . develop --path=$(pwd) exago@develop
+      #- name: Spack develop exago
+      #  run: spack -e . develop --path=$(pwd) exago@develop
 
       - name: Concretize
         run: spack -e . concretize --fresh
@@ -174,8 +174,8 @@ jobs:
         run: spack -e . install --no-check-signature --fail-fast --keep-stage --no-cache --fresh
 
       - name: Test Build
-        run: cd $(spack -e . location --build-dir exago@develop) && ctest -VV
-        if: ${{ matrix.spack_spec == 'exago@develop+mpi~ipopt+hiop~python~raja ^openmpi ^hiop~raja~sparse'}}
+        run: cd $(spack -e . location --build-dir exago@2.0.0) && ctest -VV
+        if: ${{ matrix.spack_spec == 'exago@2.0.0+mpi~ipopt+hiop~python~raja ^openmpi ^hiop~raja~sparse'}}
 
       # Push with force to override existing binaries...
       - name: Push binaries to buildcache

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -99,13 +99,13 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - exago@2.0.0+mpi~ipopt+hiop~python~raja ^openmpi ^hiop~raja~sparse
-          - exago@2.0.0+mpi~ipopt+hiop+python~raja ^openmpi ^hiop~raja~sparse
-          - exago@2.0.0+mpi~ipopt+hiop~python+raja ^openmpi ^hiop+raja~sparse
-          - exago@2.0.0+mpi+ipopt+hiop~python+raja ^openmpi ^hiop+raja~sparse
-          - exago@2.0.0+mpi+ipopt+hiop+python+raja ^openmpi ^hiop+raja~sparse
-          - exago@2.0.0+mpi+ipopt+hiop+python~raja ^openmpi ^hiop~raja~sparse
-          - exago@2.0.0+mpi+ipopt~hiop+python~raja ^openmpi
+          - exago@develop+mpi~ipopt+hiop~python~raja ^openmpi ^hiop~raja~sparse
+          - exago@develop+mpi~ipopt+hiop+python~raja ^openmpi ^hiop~raja~sparse
+          - exago@develop+mpi~ipopt+hiop~python+raja ^openmpi ^hiop+raja~sparse
+          - exago@develop+mpi+ipopt+hiop~python+raja ^openmpi ^hiop+raja~sparse
+          - exago@develop+mpi+ipopt+hiop+python+raja ^openmpi ^hiop+raja~sparse
+          - exago@develop+mpi+ipopt+hiop+python~raja ^openmpi ^hiop~raja~sparse
+          - exago@develop+mpi+ipopt~hiop+python~raja ^openmpi
 
     name: Build ExaGO with Spack
     steps:
@@ -161,8 +161,8 @@ jobs:
       - name: Spack local repo
         run: spack -e . repo add buildsystem/spack/spack_repo/exago
 
-      #- name: Spack develop exago
-      #  run: spack -e . develop --path=$(pwd) exago@develop
+      - name: Spack develop exago
+        run: spack -e . develop --path=$(pwd) exago@develop
 
       - name: Concretize
         run: spack -e . concretize --fresh
@@ -174,8 +174,8 @@ jobs:
         run: spack -e . install --no-check-signature --fail-fast --keep-stage --no-cache --fresh
 
       - name: Test Build
-        run: cd $(spack -e . location --build-dir exago@2.0.0) && ctest -VV
-        if: ${{ matrix.spack_spec == 'exago@2.0.0+mpi~ipopt+hiop~python~raja ^openmpi ^hiop~raja~sparse'}}
+        run: cd $(spack -e . location --build-dir exago@develop) && ctest -VV
+        if: ${{ matrix.spack_spec == 'exago@develop+mpi~ipopt+hiop~python~raja ^openmpi ^hiop~raja~sparse'}}
 
       # Push with force to override existing binaries...
       - name: Push binaries to buildcache

--- a/buildsystem/spack/frontier/modules/dependencies.sh
+++ b/buildsystem/spack/frontier/modules/dependencies.sh
@@ -66,8 +66,8 @@ module load coinhsl/2024.05.15-gcc-14.2.0-ke5biep
 # magma@=2.8.0~cuda+fortran~ipo+rocm+shared amdgpu_target:=gfx90a build_system=cmake build_type=Release generator=make platform=linux os=sles15 target=zen3
 module load magma/2.8.0-gcc-14.2.0-ikok5nn
 ## excluded or missing from upstream: rocprim@=6.3.1~asan amdgpu_target:=auto build_system=cmake build_type=Release generator=make platform=linux os=sles15 target=x86_64
-# raja@=2024.07.0~cuda~desul~examples~exercises~gpu-profiling~ipo~lowopttest~omptarget~omptask~openmp~plugins+rocm~run-all-tests~shared~sycl~tests~vectorization amdgpu_target:=gfx90a build_system=cmake build_type=Release commit=4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1 generator=make platform=linux os=sles15 target=zen3
-module load raja/2024.07.0-gcc-14.2.0-3e7fwpj
+# raja@=2025.03.0~cuda~desul~examples~exercises~gpu-profiling~ipo~lowopttest~omptarget~omptask~openmp~plugins+rocm~run-all-tests~shared~sycl~tests~vectorization amdgpu_target:=gfx90a build_system=cmake build_type=Release commit=1d70abf171474d331f1409908bdf1b1c3fe19222 generator=make platform=linux os=sles15 target=zen3
+module load raja/2025.03.0-gcc-14.2.0-woblane
 # libsigsegv@=2.14 build_system=autotools platform=linux os=sles15 target=zen3
 module load libsigsegv/2.14-gcc-14.2.0-j5nwpxr
 # m4@=1.4.20+sigsegv build_system=autotools platform=linux os=sles15 target=zen3
@@ -102,10 +102,10 @@ module load texinfo/7.2-gcc-14.2.0-wtmf5g5
 module load mpfr/4.2.1-gcc-14.2.0-p4r33ds
 # suite-sparse@=7.8.3~cuda~graphblas~openmp+pic build_system=generic platform=linux os=sles15 target=zen3
 module load suite-sparse/7.8.3-gcc-14.2.0-3f2u2ru
-# umpire@=2024.07.0~asan~backtrace+c~cuda~dev_benchmarks~device_alloc~deviceconst~examples+fmt_header_only~fortran~ipc_shmem~ipo~mpi~mpi3_shmem~numa~omptarget~openmp+rocm~sanitizer_tests+shared~sqlite_experimental~tools~werror amdgpu_target:=gfx90a build_system=cmake build_type=Release commit=abd729f40064175e999a83d11d6b073dac4c01d2 generator=make tests=none platform=linux os=sles15 target=zen3
-module load umpire/2024.07.0-gcc-14.2.0-tzf24hf
+# umpire@=2025.03.0~asan~backtrace+c~cuda~dev_benchmarks~device_alloc~deviceconst~examples+fmt_header_only~fortran~ipc_shmem~ipo~mpi~mpi3_shmem~numa~omptarget~openmp+rocm~sanitizer_tests+shared~sqlite_experimental~tools~werror amdgpu_target:=gfx90a build_system=cmake build_type=Release commit=1ed0669c57f041baa1f1070693991c3a7a43e7ee generator=make tests=none platform=linux os=sles15 target=zen3
+module load umpire/2025.03.0-gcc-14.2.0-bhfur45
 # hiop@=1.1.1~axom~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target:=gfx90a build_system=cmake build_type=Release commit=d8762e05150b2040a27f69d8bf6603f22190a869 generator=make platform=linux os=sles15 target=zen3
-module load hiop/1.1.1-gcc-14.2.0-beu4x7r
+module load hiop/1.1.1-gcc-14.2.0-a2bwjiu
 # ipopt@=3.14.14+coinhsl~debug~java~metis~mumps build_system=autotools platform=linux os=sles15 target=zen3
 module load ipopt/3.14.14-gcc-14.2.0-gj4qlx4
 # parmetis@=4.0.3~gdb~int64~ipo+shared build_system=cmake build_type=Release generator=make patches:=4f89253,50ed208,704b84f platform=linux os=sles15 target=zen3
@@ -114,5 +114,5 @@ module load parmetis/4.0.3-gcc-14.2.0-xatjoum
 module load petsc/3.24.1-gcc-14.2.0-4izpiqe
 # spdlog@=1.15.0~ipo+shared build_system=cmake build_type=Release generator=make patches:=5ed92f4,fd4cbb1,fdc325d platform=linux os=sles15 target=zen3
 module load spdlog/1.15.0-gcc-14.2.0-56k2ubv
-# exago@=develop~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target:=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Tmp/ExaGO generator=make platform=linux os=sles15 target=zen3
-## module load exago/develop-gcc-14.2.0-lj7562k
+# exago@=develop~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm+testing amdgpu_target:=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO generator=make platform=linux os=sles15 target=zen3
+## module load exago/develop-gcc-14.2.0-yzuty4x

--- a/buildsystem/spack/frontier/modules/exago.sh
+++ b/buildsystem/spack/frontier/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/stf006/world-shared/nkouk/exago-02-2026/spack-install/modules/linux-sles15-zen3
-# exago@=develop~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target:=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Tmp/ExaGO generator=make platform=linux os=sles15 target=zen3
-module load exago/develop-gcc-14.2.0-lj7562k
+# exago@=develop~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm+testing amdgpu_target:=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO generator=make platform=linux os=sles15 target=zen3
+module load exago/develop-gcc-14.2.0-yzuty4x

--- a/buildsystem/spack/spack_repo/exago/packages/exago/package.py
+++ b/buildsystem/spack/spack_repo/exago/packages/exago/package.py
@@ -156,8 +156,8 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cuda", when="+cuda")
     depends_on("raja", when="+raja")
     depends_on("umpire", when="+raja")
-    depends_on("spdlog", when="@develop+logging")
-    depends_on("fmt", when="@develop+logging")
+    depends_on("spdlog", when="@2.0:+logging")
+    depends_on("fmt", when="@2.0:+logging")
     depends_on("cmake@3.18:", type="build")
 
     # Profiling
@@ -200,7 +200,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hiop@0.5.1:", when="@1.1.0:+hiop")
     depends_on("hiop@0.5.3:", when="@1.3.0:+hiop")
     depends_on("hiop@0.7.0:1.0.0", when="@1.5.0:1.6.0+hiop")
-    depends_on("hiop@1.0.1:", when="@develop:+hiop")
+    depends_on("hiop@1.0.1:", when="@2.0:+hiop")
 
     depends_on("hiop~mpi", when="+hiop~mpi")
     depends_on("hiop+mpi", when="+hiop+mpi")

--- a/buildsystem/spack/spack_repo/exago/packages/exago/package.py
+++ b/buildsystem/spack/spack_repo/exago/packages/exago/package.py
@@ -32,6 +32,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     version(
         "2.0.0",
         tag="v2.0.0",
+        commit="d80d9a00914c096121832c6bb778d83b0b40c3c9",
         submodules=submodules,
     )
     version(
@@ -218,12 +219,12 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("petsc@3.16", when="@1.3:1.4")
     depends_on("petsc@3.18:3.19", when="@1.5")
     depends_on("petsc@3.19:3.23", when="@1.6")
-    depends_on("petsc@3.24:", when="@develop")
+    depends_on("petsc@3.24:", when="@2.0:")
     depends_on("petsc~mpi", when="~mpi")
 
     # Ipopt versiondependency logic
     depends_on("ipopt@3.12", when="@:1.6")
-    depends_on("ipopt@3.14:", when="@develop")
+    depends_on("ipopt@3.14:", when="@2.0:")
 
     # cuda_arch and amdgpu_target dependency logic
     for arch in CudaPackage.cuda_arch_values:


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [ ] Documentation
- [x] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [x] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [x] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

This updates the local repo Spack package for ExaGO to match the version [pushed upstream for the 2.0 release](https://github.com/spack/spack-packages/pull/4930).

Minor Frontier module updates after testing the proposed changes (pulling more recent versions of some packages).