### PR TITLE
Do not store std::string in PETSc-allocated structs

### DIFF
--- a/include/private/opflowimpl.h
+++ b/include/private/opflowimpl.h
@@ -218,13 +218,13 @@ struct _p_OPFLOW {
 
   void *solver; /* Solver object */
   struct _p_OPFLOWSolverOps solverops;
-  std::string solvername;
+  char solvername[32];
 
   void *model; /* Model object */
   struct _p_OPFLOWModelOps modelops;
-  std::string modelname;
+  char modelname[32];
 
-  std::string _p_hiop_compute_mode;
+  char _p_hiop_compute_mode[32];
   int _p_hiop_verbosity_level;
 
   /* List of models and solvers registered */

--- a/include/private/scopflowimpl.h
+++ b/include/private/scopflowimpl.h
@@ -172,7 +172,7 @@ struct _p_SCOPFLOW {
 
   void *model; /* Model object */
   struct _p_SCOPFLOWModelOps modelops;
-  std::string modelname;
+  char modelname[32];
 
   struct _p_SCOPFLOWModelList SCOPFLOWModelList[SCOPFLOWMODELSMAX];
   PetscInt nmodelsregistered;
@@ -180,7 +180,7 @@ struct _p_SCOPFLOW {
 
   void *solver; /* Solver object */
   struct _p_SCOPFLOWSolverOps solverops;
-  std::string solvername;
+  char solvername[32];
 
   /* List of solvers registered */
   struct _p_SCOPFLOWSolverList SCOPFLOWSolverList[SCOPFLOWSOLVERSMAX];
@@ -209,11 +209,11 @@ struct _p_SCOPFLOW {
   PetscBool ignore_lineflow_constraints; /* Ignore lineflow constraints */
 
   /* Used by HIOP solver */
-  std::string subproblem_model;  /* subproblem model */
-  std::string subproblem_solver; /* subproblem solver */
-  std::string compute_mode;
+  char subproblem_model[32];  /* subproblem model */
+  char subproblem_solver[32]; /* subproblem solver */
+  char compute_mode[32];
   int verbosity_level;
-  std::string mem_space; /* Memory space used in HIOP */
+  char mem_space[32]; /* Memory space used in HIOP */
 
   /** @brief Logging events that apply to interface */
   PetscLogEvent outputlogger;

--- a/include/private/sopflowimpl.h
+++ b/include/private/sopflowimpl.h
@@ -219,11 +219,11 @@ struct _p_SOPFLOW {
   PetscBool issolver_hiop;
 
   // Only used for HIOP solver
-  std::string subproblem_model;
-  std::string subproblem_solver;
-  std::string compute_mode;
+  char subproblem_model[32];
+  char subproblem_solver[32];
+  char compute_mode[32];
   int verbosity_level;
-  std::string mem_space; /* Memory space used with HIOP */
+  char mem_space[32]; /* Memory space used with HIOP */
 
   /** @brief Logging events that apply to interface */
   PetscLogEvent outputlogger;

--- a/src/opflow/interface/opflow.cpp
+++ b/src/opflow/interface/opflow.cpp
@@ -313,7 +313,9 @@ PetscErrorCode OPFLOWGetBusPowerImbalancePenalty(OPFLOW opflow,
 */
 PetscErrorCode OPFLOWSetHIOPComputeMode(OPFLOW opflow, const std::string mode) {
   PetscFunctionBegin;
-  opflow->_p_hiop_compute_mode = mode;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(opflow->_p_hiop_compute_mode, mode.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -802,8 +804,11 @@ PetscErrorCode OPFLOWCreate(MPI_Comm mpicomm, OPFLOW *opflowout) {
   ierr = PSSetApplication(opflow->ps, opflow, APP_ACOPF);
   CHKERRQ(ierr);
 
-  opflow->modelname = OPFLOWOptions::model.opt;
-  opflow->solvername = OPFLOWOptions::solver.opt;
+  ierr = PetscStrcpy(opflow->modelname, OPFLOWOptions::model.opt.c_str());
+  CHKERRQ(ierr);
+
+  ierr = PetscStrcpy(opflow->solvername, OPFLOWOptions::solver.opt.c_str());
+  CHKERRQ(ierr);
 
   opflow->Nconeq = opflow->nconeq = -1;
   opflow->Nconineq = opflow->nconineq = -1;
@@ -876,7 +881,9 @@ PetscErrorCode OPFLOWCreate(MPI_Comm mpicomm, OPFLOW *opflowout) {
   opflow->nlinesmon = 0;
   opflow->linesmon = NULL;
 
-  opflow->_p_hiop_compute_mode = "auto";
+  ierr = PetscStrcpy(opflow->_p_hiop_compute_mode, "auto");
+  CHKERRQ(ierr);
+
   opflow->_p_hiop_verbosity_level = 0;
 
   opflow->skip_options = PETSC_FALSE;
@@ -1103,7 +1110,9 @@ PetscErrorCode OPFLOWSetSolver(OPFLOW opflow, const std::string solvername) {
   opflow->solverops.solve = 0;
   opflow->solverops.setup = 0;
 
-  opflow->solvername = solvername;
+  ierr = PetscStrcpy(opflow->solvername, solvername.c_str());
+  CHKERRQ(ierr);
+
   /* Call the underlying implementation constructor */
   ierr = (*r)(opflow);
   CHKERRQ(ierr);
@@ -1196,7 +1205,9 @@ PetscErrorCode OPFLOWSetModel(OPFLOW opflow, const std::string modelname) {
   opflow->modelops.computeauxgradient = 0;
   opflow->modelops.computeauxhessian = 0;
 
-  opflow->modelname = modelname;
+  ierr = PetscStrcpy(opflow->modelname, modelname.c_str());
+  CHKERRQ(ierr);
+
   /* Call the underlying implementation constructor */
   ierr = (*r)(opflow);
   CHKERRQ(ierr);
@@ -3209,67 +3220,76 @@ PetscErrorCode OPFLOWSetSummaryStats(OPFLOW opflow) {
  */
 PetscErrorCode OPFLOWCheckModelSolverCompatibility(OPFLOW opflow) {
   PetscFunctionBegin;
+  PetscErrorCode ierr;
 #if defined(EXAGO_ENABLE_IPOPT)
   PetscBool ipopt, ipopt_pbpol, ipopt_pbcar, ipopt_ibcar, ipopt_ibcar2,
       ipopt_dcopf;
-  ipopt = static_cast<PetscBool>(opflow->solvername == OPFLOWSOLVER_IPOPT);
-  ipopt_pbpol = static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_PBPOL);
-  ipopt_pbcar = static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_PBCAR);
-  ipopt_ibcar = static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_IBCAR);
-  ipopt_ibcar2 =
-      static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_IBCAR2);
-  ipopt_dcopf = static_cast<PetscBool>(opflow->modelname == "DCOPF");
+  ierr = PetscStrcmp(opflow->solvername, OPFLOWSOLVER_IPOPT, &ipopt);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOL, &ipopt_pbpol);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBCAR, &ipopt_pbcar);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_IBCAR, &ipopt_ibcar);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_IBCAR2, &ipopt_ibcar2);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, "DCOPF", &ipopt_dcopf);
+  CHKERRQ(ierr);
   if (ipopt && !(ipopt_pbpol || ipopt_pbcar || ipopt_ibcar || ipopt_ibcar2 ||
                  ipopt_dcopf)) {
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,
             "OPFLOW solver IPOPT incompatible with model %s",
-            opflow->modelname.c_str());
+            opflow->modelname);
   }
 #endif
 #if defined(EXAGO_ENABLE_HIOP)
   PetscBool hiop, hiop_pbpol;
-  hiop = static_cast<PetscBool>(opflow->solvername == OPFLOWSOLVER_HIOP);
-  hiop_pbpol =
-      static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_PBPOLHIOP);
+  ierr = PetscStrcmp(opflow->solvername, OPFLOWSOLVER_HIOP, &hiop);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOLHIOP, &hiop_pbpol);
+  CHKERRQ(ierr);
 #if defined(EXAGO_ENABLE_RAJA)
   PetscBool rajahiop_pbpol;
-  rajahiop_pbpol =
-      static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_PBPOLRAJAHIOP);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOLRAJAHIOP,
+                     &rajahiop_pbpol);
+  CHKERRQ(ierr);
 #else
   PetscBool rajahiop_pbpol = PETSC_FALSE;
 #endif // RAJA
   if (hiop && !(hiop_pbpol || rajahiop_pbpol)) {
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,
-            "OPFLOW solver HIOP incompatible with model %s",
-            (opflow->modelname).c_str());
+            "OPFLOW solver HIOP incompatible with model %s", opflow->modelname);
   }
 #if defined(EXAGO_ENABLE_HIOP_SPARSE)
   PetscBool hiop_sparse;
   PetscBool hiop_sparse_pbpol;
   PetscBool hiop_sparse_dcopf;
-  hiop_sparse =
-      static_cast<PetscBool>(opflow->solvername == OPFLOWSOLVER_HIOPSPARSE);
-  hiop_sparse_pbpol =
-      static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_PBPOL);
-  hiop_sparse_dcopf = static_cast<PetscBool>(opflow->modelname == "DCOPF");
+  ierr = PetscStrcmp(opflow->solvername, OPFLOWSOLVER_HIOPSPARSE, &hiop_sparse);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOL, &hiop_sparse_pbpol);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, "DCOPF", &hiop_sparse_dcopf);
+  CHKERRQ(ierr);
   if (hiop_sparse && !(hiop_sparse_pbpol || hiop_sparse_dcopf)) {
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,
             "OPFLOW solver HIOPSPARSE incompatible with model %s",
-            (opflow->modelname).c_str());
+            opflow->modelname);
   }
 #if defined(EXAGO_ENABLE_RAJA)
   PetscBool hiop_sparsegpu;
   PetscBool pbpolrajahiopsparse;
-
-  hiop_sparsegpu =
-      static_cast<PetscBool>(opflow->solvername == OPFLOWSOLVER_HIOPSPARSEGPU);
-  pbpolrajahiopsparse = static_cast<PetscBool>(opflow->modelname ==
-                                               OPFLOWMODEL_PBPOLRAJAHIOPSPARSE);
+  ierr = PetscStrcmp(opflow->solvername, OPFLOWSOLVER_HIOPSPARSEGPU,
+                     &hiop_sparsegpu);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOLRAJAHIOPSPARSE,
+                     &pbpolrajahiopsparse);
+  CHKERRQ(ierr);
 
   if (hiop_sparsegpu && !pbpolrajahiopsparse) {
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,
             "OPFLOW solver HIOPSPARSE incompatible with model %s",
-            (opflow->modelname).c_str());
+            opflow->modelname);
   }
 #endif // EXAGO_ENABLE_RAJA
 #endif // HIOP_SPARSE
@@ -3279,7 +3299,7 @@ PetscErrorCode OPFLOWCheckModelSolverCompatibility(OPFLOW opflow) {
     if (rajahiop_pbpol) {
       SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,
               "OPFLOW load shedding incompatible with model %s",
-              (opflow->modelname).c_str());
+              opflow->modelname);
     }
   }
 #endif // HIOP

--- a/src/opflow/interface/opflowoutput.cpp
+++ b/src/opflow/interface/opflowoutput.cpp
@@ -30,11 +30,11 @@ PetscErrorCode OPFLOWPrintSolution(OPFLOW opflow) {
       opflow->comm->type,
       "=============================================================\n");
   CHKERRQ(ierr);
-  ierr = PetscPrintf(opflow->comm->type, "%-35s %s\n", "Model",
-                     opflow->modelname.c_str());
+  ierr =
+      PetscPrintf(opflow->comm->type, "%-35s %s\n", "Model", opflow->modelname);
   CHKERRQ(ierr);
   ierr = PetscPrintf(opflow->comm->type, "%-35s %s\n", "Solver",
-                     opflow->solvername.c_str());
+                     opflow->solvername);
   CHKERRQ(ierr);
   ierr = PetscPrintf(opflow->comm->type, "%-35s %s\n", "Objective",
                      OPFLOWObjectiveTypes[opflow->objectivetype]);

--- a/src/opflow/solver/hiop/opflow_hiop.cpp
+++ b/src/opflow/solver/hiop/opflow_hiop.cpp
@@ -357,7 +357,7 @@ PetscErrorCode OPFLOWSolverSetUp_HIOP(OPFLOW opflow) {
 
   if (mode_set == PETSC_FALSE) {
     hiop->mds->options->SetStringValue("compute_mode",
-                                       opflow->_p_hiop_compute_mode.c_str());
+                                       opflow->_p_hiop_compute_mode);
   } else {
     hiop->mds->options->SetStringValue("compute_mode",
                                        HIOPComputeModeChoices[compute_mode]);
@@ -428,16 +428,17 @@ PetscErrorCode OPFLOWSolverSetUp_HIOP(OPFLOW opflow) {
   hiop->mds->options->SetStringValue("scaling_type", "none");
 
   /* Error if model is not power balance hiop or power balance raja hiop */
-  ismodelpbpolhiop =
-      static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_PBPOLHIOP);
+  ierr =
+      PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOLHIOP, &ismodelpbpolhiop);
+  CHKERRQ(ierr);
 #if defined(EXAGO_ENABLE_RAJA)
-  ismodelpbpolrajahiop =
-      static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_PBPOLRAJAHIOP);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOLRAJAHIOP,
+                     &ismodelpbpolrajahiop);
+  CHKERRQ(ierr);
 #endif
   if (!ismodelpbpolhiop && !ismodelpbpolrajahiop) {
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,
-            "%s opflow model not supported with HIOP\n",
-            opflow->modelname.c_str());
+            "%s opflow model not supported with HIOP\n", opflow->modelname);
     PetscFunctionReturn(1);
     exit(0);
   }

--- a/src/opflow/solver/hiop/opflow_hiopsparse.cpp
+++ b/src/opflow/solver/hiop/opflow_hiopsparse.cpp
@@ -666,7 +666,8 @@ PetscErrorCode OPFLOWSolverSetUp_HIOPSPARSE(OPFLOW opflow) {
   hiop->solver = new hiop::hiopAlgFilterIPMNewton(hiop->sp);
 
   /* Error if model is not power balance hiop */
-  flg1 = static_cast<PetscBool>(opflow->modelname == OPFLOWMODEL_PBPOL);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOL, &flg1);
+  CHKERRQ(ierr);
   if (!flg1) {
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,
             "Only power balance polar model allowed\n Run with -opflow_model "

--- a/src/opflow/solver/hiop/opflow_hiopsparsegpu.cpp
+++ b/src/opflow/solver/hiop/opflow_hiopsparsegpu.cpp
@@ -397,8 +397,7 @@ PetscErrorCode OPFLOWSolverSetUp_HIOPSPARSEGPU(OPFLOW opflow) {
   hiop->solver = new hiop::hiopAlgFilterIPMNewton(hiop->sp);
 
   /* Error if model is not power balance hiop */
-  ierr = PetscStrcmp(opflow->modelname.c_str(), OPFLOWMODEL_PBPOLRAJAHIOPSPARSE,
-                     &flg1);
+  ierr = PetscStrcmp(opflow->modelname, OPFLOWMODEL_PBPOLRAJAHIOPSPARSE, &flg1);
   CHKERRQ(ierr);
   if (!flg1) {
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -75,24 +75,16 @@ PetscErrorCode SCOPFLOWCreate(MPI_Comm mpicomm, SCOPFLOW *scopflowout) {
   scopflow->gicfileset = PETSC_FALSE;
 
   /* Default subproblem model and solver */
-#if 0
-  (void)std::strncpy(scopflow->subproblem_model,
-                     SCOPFLOWOptions::subproblem_model.default_value.c_str(),
-                     sizeof(scopflow->subproblem_model));
-  (void)std::strncpy(scopflow->subproblem_solver,
-                     SCOPFLOWOptions::subproblem_solver.default_value.c_str(),
-                     sizeof(scopflow->subproblem_solver));
-#endif
-  scopflow->subproblem_model = SCOPFLOWOptions::subproblem_model.default_value;
-  scopflow->subproblem_solver =
-      SCOPFLOWOptions::subproblem_solver.default_value;
+  ierr = PetscStrcpy(scopflow->subproblem_model,
+                     SCOPFLOWOptions::subproblem_model.default_value.c_str());
+  CHKERRQ(ierr);
+  ierr = PetscStrcpy(scopflow->subproblem_solver,
+                     SCOPFLOWOptions::subproblem_solver.default_value.c_str());
+  CHKERRQ(ierr);
 #ifdef EXAGO_ENABLE_HIOP
-#if 0
-  (void)std::strncpy(scopflow->compute_mode,
-                     SCOPFLOWOptions::compute_mode.default_value.c_str(),
-                     sizeof(scopflow->compute_mode));
-#endif
-  scopflow->compute_mode = SCOPFLOWOptions::compute_mode.default_value.c_str();
+  ierr = PetscStrcpy(scopflow->compute_mode,
+                     SCOPFLOWOptions::compute_mode.default_value.c_str());
+  CHKERRQ(ierr);
   scopflow->verbosity_level = SCOPFLOWOptions::verbosity_level.default_value;
 #endif
 
@@ -293,7 +285,9 @@ PetscErrorCode SCOPFLOWSetModel(SCOPFLOW scopflow,
   scopflow->modelops.computetotalobjective = 0;
   scopflow->modelops.computegradient = 0;
 
-  scopflow->modelname = modelname;
+  ierr = PetscStrcpy(scopflow->modelname, modelname.c_str());
+  CHKERRQ(ierr);
+
   /* Call the underlying implementation constructor */
   ierr = (*r)(scopflow);
   CHKERRQ(ierr);
@@ -332,7 +326,9 @@ PetscErrorCode SCOPFLOWSetSolver(SCOPFLOW scopflow,
   scopflow->solverops.solve = 0;
   scopflow->solverops.setup = 0;
 
-  scopflow->solvername = solvername;
+  ierr = PetscStrcpy(scopflow->solvername, solvername.c_str());
+  CHKERRQ(ierr);
+
   /* Call the underlying implementation constructor */
   ierr = (*r)(scopflow);
   CHKERRQ(ierr);
@@ -525,27 +521,34 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
   ierr =
       PetscOptionsString(SCOPFLOWOptions::subproblem_model.opt.c_str(),
                          SCOPFLOWOptions::subproblem_model.desc.c_str(), "",
-                         scopflow->subproblem_model.c_str(),
+                         scopflow->subproblem_model,
                          scopflowsubproblemmodelname, max_model_name_len, &flg);
   CHKERRQ(ierr);
-  if (flg)
-    scopflow->subproblem_model = scopflowsubproblemmodelname;
+  if (flg) {
+    ierr = PetscStrcpy(scopflow->subproblem_model, scopflowsubproblemmodelname);
+    CHKERRQ(ierr);
+  }
   ierr = PetscOptionsString(SCOPFLOWOptions::subproblem_solver.opt.c_str(),
                             SCOPFLOWOptions::subproblem_solver.desc.c_str(), "",
-                            scopflow->subproblem_solver.c_str(),
+                            scopflow->subproblem_solver,
                             scopflowsubproblemsolvername, max_solver_name_len,
                             NULL);
   CHKERRQ(ierr);
-  if (flg)
-    scopflow->subproblem_solver = scopflowsubproblemsolvername;
+  if (flg) {
+    ierr =
+        PetscStrcpy(scopflow->subproblem_solver, scopflowsubproblemsolvername);
+    CHKERRQ(ierr);
+  }
 #ifdef EXAGO_ENABLE_HIOP
   ierr = PetscOptionsString(SCOPFLOWOptions::compute_mode.opt.c_str(),
                             SCOPFLOWOptions::compute_mode.desc.c_str(), "",
-                            scopflow->compute_mode.c_str(), computemodename,
+                            scopflow->compute_mode, computemodename,
                             max_model_name_len, &flg);
   CHKERRQ(ierr);
-  if (flg)
-    scopflow->compute_mode = computemodename;
+  if (flg) {
+    ierr = PetscStrcpy(scopflow->compute_mode, computemodename);
+    CHKERRQ(ierr);
+  }
   ierr = PetscOptionsInt(SCOPFLOWOptions::verbosity_level.opt.c_str(),
                          SCOPFLOWOptions::verbosity_level.desc.c_str(), "",
                          scopflow->verbosity_level, &scopflow->verbosity_level,
@@ -603,12 +606,13 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
 #ifdef EXAGO_ENABLE_HIOP
   ierr = PetscOptionsString(SCOPFLOWOptions::hiop_mem_space.opt.c_str(),
                             SCOPFLOWOptions::hiop_mem_space.desc.c_str(), "",
-                            scopflow->mem_space.c_str(),
-                            scopflowsubproblemmemspacename, max_model_name_len,
-                            &flg);
+                            scopflow->mem_space, scopflowsubproblemmemspacename,
+                            max_model_name_len, &flg);
   CHKERRQ(ierr);
-  if (flg)
-    scopflow->mem_space = scopflowsubproblemmemspacename;
+  if (flg) {
+    ierr = PetscStrcpy(scopflow->mem_space, scopflowsubproblemmemspacename);
+    CHKERRQ(ierr);
+  }
 #endif
   PetscOptionsEnd();
 
@@ -1031,7 +1035,7 @@ PetscErrorCode SCOPFLOWSolve(SCOPFLOW scopflow) {
     ierr = SCOPFLOWSetUp(scopflow);
   }
 
-  ierr = PetscStrcmp(scopflow->solvername.c_str(), "IPOPT", &issolver_ipopt);
+  ierr = PetscStrcmp(scopflow->solvername, "IPOPT", &issolver_ipopt);
   CHKERRQ(ierr);
 
   if (issolver_ipopt) { /* Don't need to do this if solver is not ipopt */
@@ -1411,7 +1415,9 @@ PetscErrorCode SCOPFLOWSetGICData(SCOPFLOW scopflow, const char gicfile[]) {
 PetscErrorCode SCOPFLOWSetSubproblemModel(SCOPFLOW scopflow,
                                           const std::string modelname) {
   PetscFunctionBegin;
-  scopflow->subproblem_model = modelname;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(scopflow->subproblem_model, modelname.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -1429,7 +1435,9 @@ PetscErrorCode SCOPFLOWSetSubproblemModel(SCOPFLOW scopflow,
 PetscErrorCode SCOPFLOWSetSubproblemSolver(SCOPFLOW scopflow,
                                            const std::string solvername) {
   PetscFunctionBegin;
-  scopflow->subproblem_solver = solvername;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(scopflow->subproblem_solver, solvername.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -1447,7 +1455,9 @@ PetscErrorCode SCOPFLOWSetSubproblemSolver(SCOPFLOW scopflow,
 PetscErrorCode SCOPFLOWSetSubproblemComputeMode(SCOPFLOW scopflow,
                                                 const std::string mode) {
   PetscFunctionBegin;
-  scopflow->compute_mode = mode;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(scopflow->compute_mode, mode.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -1483,6 +1493,8 @@ PetscErrorCode SCOPFLOWSetSubproblemVerbosityLevel(SCOPFLOW scopflow,
 PetscErrorCode SCOPFLOWSetSubproblemMemSpace(SCOPFLOW scopflow,
                                              const std::string mem_space) {
   PetscFunctionBegin;
-  scopflow->mem_space = mem_space;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(scopflow->mem_space, mem_space.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }

--- a/src/scopflow/interface/scopflowoutput.cpp
+++ b/src/scopflow/interface/scopflowoutput.cpp
@@ -94,7 +94,7 @@ PetscErrorCode SCOPFLOWPrintSolution(SCOPFLOW scopflow, PetscInt cont_num) {
     CHKERRQ(ierr);
 
     ierr = PetscPrintf(scopflow->comm->type, "%-35s %s\n", "Solver",
-                       scopflow->solvername.c_str());
+                       scopflow->solvername);
     CHKERRQ(ierr);
 
     ierr = PetscPrintf(scopflow->comm->type, "%-35s %s\n", "Initialization",

--- a/src/scopflow/solver/hiop/scopflow_hiop.cpp
+++ b/src/scopflow/solver/hiop/scopflow_hiop.cpp
@@ -177,7 +177,8 @@ bool SCOPFLOWHIOPInterface::eval_f_rterm(hiop::size_type idx, const int &n,
   ierr = OPFLOWSetSolver(opflowctgc, scopflow->subproblem_solver);
   CHKERRQ(ierr);
   PetscBool issubproblemsolver_hiop;
-  ierr = PetscStrcmp(scopflow->subproblem_solver, "HIOP", &issubproblemsolver_hiop);
+  ierr = PetscStrcmp(scopflow->subproblem_solver, "HIOP",
+                     &issubproblemsolver_hiop);
   CHKERRQ(ierr);
   if (issubproblemsolver_hiop) {
     ierr = OPFLOWSetHIOPComputeMode(opflowctgc, scopflow->compute_mode);

--- a/src/scopflow/solver/hiop/scopflow_hiop.cpp
+++ b/src/scopflow/solver/hiop/scopflow_hiop.cpp
@@ -176,7 +176,10 @@ bool SCOPFLOWHIOPInterface::eval_f_rterm(hiop::size_type idx, const int &n,
   CHKERRQ(ierr);
   ierr = OPFLOWSetSolver(opflowctgc, scopflow->subproblem_solver);
   CHKERRQ(ierr);
-  if (scopflow->subproblem_solver == "HIOP") {
+  PetscBool issubproblemsolver_hiop;
+  ierr = PetscStrcmp(scopflow->subproblem_solver, "HIOP", &issubproblemsolver_hiop);
+  CHKERRQ(ierr);
+  if (issubproblemsolver_hiop) {
     ierr = OPFLOWSetHIOPComputeMode(opflowctgc, scopflow->compute_mode);
     CHKERRQ(ierr);
     ierr = OPFLOWSetHIOPVerbosityLevel(opflowctgc, scopflow->verbosity_level);

--- a/src/sopflow/interface/sopflow.cpp
+++ b/src/sopflow/interface/sopflow.cpp
@@ -40,8 +40,12 @@ PetscErrorCode SOPFLOWCreate(MPI_Comm mpicomm, SOPFLOW *sopflowout) {
   sopflow->model = NULL;
 
   /* Default subproblemmodel and solver */
-  sopflow->subproblem_model = SOPFLOWOptions::subproblem_model.default_value;
-  sopflow->subproblem_solver = SOPFLOWOptions::subproblem_model.default_value;
+  ierr = PetscStrcpy(sopflow->subproblem_model,
+                     SOPFLOWOptions::subproblem_model.default_value.c_str());
+  CHKERRQ(ierr);
+  ierr = PetscStrcpy(sopflow->subproblem_solver,
+                     SOPFLOWOptions::subproblem_solver.default_value.c_str());
+  CHKERRQ(ierr);
 
   sopflow->mode = SOPFLOWOptions::mode.default_value;
 
@@ -72,7 +76,8 @@ PetscErrorCode SOPFLOWCreate(MPI_Comm mpicomm, SOPFLOW *sopflowout) {
 
 #if defined(EXAGO_ENABLE_HIOP)
   /* HIOP options */
-  sopflow->compute_mode = "auto";
+  ierr = PetscStrcpy(sopflow->compute_mode, "auto");
+  CHKERRQ(ierr);
   sopflow->verbosity_level = 0;
 #endif
 
@@ -625,19 +630,23 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
   ierr =
       PetscOptionsString(SOPFLOWOptions::subproblem_model.opt.c_str(),
                          SOPFLOWOptions::subproblem_model.desc.c_str(), "",
-                         sopflow->subproblem_model.c_str(),
-                         sopflowsubproblemmodelname, max_model_name_len, &flg);
+                         sopflow->subproblem_model, sopflowsubproblemmodelname,
+                         max_model_name_len, &flg);
   CHKERRQ(ierr);
-  if (flg)
-    sopflow->subproblem_model = sopflowsubproblemmodelname;
+  if (flg) {
+    ierr = PetscStrcpy(sopflow->subproblem_model, sopflowsubproblemmodelname);
+    CHKERRQ(ierr);
+  }
   ierr = PetscOptionsString(SOPFLOWOptions::subproblem_solver.opt.c_str(),
                             SOPFLOWOptions::subproblem_solver.desc.c_str(), "",
-                            sopflow->subproblem_solver.c_str(),
+                            sopflow->subproblem_solver,
                             sopflowsubproblemsolvername, max_solver_name_len,
                             &flg);
   CHKERRQ(ierr);
-  if (flg)
-    sopflow->subproblem_solver = sopflowsubproblemsolvername;
+  if (flg) {
+    ierr = PetscStrcpy(sopflow->subproblem_solver, sopflowsubproblemsolvername);
+    CHKERRQ(ierr);
+  }
 
   ierr = PetscOptionsBool(SOPFLOWOptions::iscoupling.opt.c_str(),
                           SOPFLOWOptions::iscoupling.desc.c_str(), "",
@@ -682,14 +691,15 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
                           sopflow->tolerance, &sopflow->tolerance, NULL);
   CHKERRQ(ierr);
 #ifdef EXAGO_ENABLE_HIOP
-  ierr =
-      PetscOptionsString(SOPFLOWOptions::hiop_mem_space.opt.c_str(),
-                         SOPFLOWOptions::hiop_mem_space.desc.c_str(), "",
-                         sopflow->mem_space.c_str(), sopflowsubproblemmemspace,
-                         PETSC_MAX_PATH_LEN, &flg);
+  ierr = PetscOptionsString(SOPFLOWOptions::hiop_mem_space.opt.c_str(),
+                            SOPFLOWOptions::hiop_mem_space.desc.c_str(), "",
+                            sopflow->mem_space, sopflowsubproblemmemspace,
+                            PETSC_MAX_PATH_LEN, &flg);
   CHKERRQ(ierr);
-  if (flg)
-    sopflow->mem_space = sopflowsubproblemmemspace;
+  if (flg) {
+    ierr = PetscStrcpy(sopflow->mem_space, sopflowsubproblemmemspace);
+    CHKERRQ(ierr);
+  }
 #endif
   PetscOptionsEnd();
 
@@ -1491,7 +1501,9 @@ PetscErrorCode SOPFLOWSetLoadProfiles(SOPFLOW sopflow,
 PetscErrorCode SOPFLOWSetSubproblemModel(SOPFLOW sopflow,
                                          const std::string modelname) {
   PetscFunctionBegin;
-  sopflow->subproblem_model = modelname;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(sopflow->subproblem_model, modelname.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -1509,7 +1521,9 @@ PetscErrorCode SOPFLOWSetSubproblemModel(SOPFLOW sopflow,
 PetscErrorCode SOPFLOWSetSubproblemSolver(SOPFLOW sopflow,
                                           const std::string solvername) {
   PetscFunctionBegin;
-  sopflow->subproblem_solver = solvername;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(sopflow->subproblem_solver, solvername.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -1527,7 +1541,9 @@ PetscErrorCode SOPFLOWSetSubproblemSolver(SOPFLOW sopflow,
 PetscErrorCode SOPFLOWSetSubproblemComputeMode(SOPFLOW sopflow,
                                                const std::string mode) {
   PetscFunctionBegin;
-  sopflow->compute_mode = mode;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(sopflow->compute_mode, mode.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -1562,6 +1578,8 @@ PetscErrorCode SOPFLOWSetSubproblemVerbosityLevel(SOPFLOW sopflow, int level) {
 PetscErrorCode SOPFLOWSetSubproblemMemSpace(SOPFLOW sopflow,
                                             const std::string mem_space) {
   PetscFunctionBegin;
-  sopflow->mem_space = mem_space;
+  PetscErrorCode ierr;
+  ierr = PetscStrcpy(sopflow->mem_space, mem_space.c_str());
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }

--- a/src/sopflow/solver/hiop/sopflow_hiop.cpp
+++ b/src/sopflow/solver/hiop/sopflow_hiop.cpp
@@ -190,8 +190,8 @@ bool SOPFLOWHIOPInterface::eval_f_rterm(hiop::size_type idx, const int &n,
   CHKERRQ(ierr);
   ierr = OPFLOWSetSolver(opflowscen, sopflow->subproblem_solver);
   CHKERRQ(ierr);
-  issubproblemsolver_hiop =
-      static_cast<PetscBool>(sopflow->subproblem_solver == "HIOP");
+  ierr = PetscStrcmp(sopflow->subproblem_solver, "HIOP", &issubproblemsolver_hiop);
+  CHKERRQ(ierr);
   if (issubproblemsolver_hiop) {
     ierr = OPFLOWSetHIOPComputeMode(opflowscen, sopflow->compute_mode);
     CHKERRQ(ierr);

--- a/src/sopflow/solver/hiop/sopflow_hiop.cpp
+++ b/src/sopflow/solver/hiop/sopflow_hiop.cpp
@@ -190,7 +190,8 @@ bool SOPFLOWHIOPInterface::eval_f_rterm(hiop::size_type idx, const int &n,
   CHKERRQ(ierr);
   ierr = OPFLOWSetSolver(opflowscen, sopflow->subproblem_solver);
   CHKERRQ(ierr);
-  ierr = PetscStrcmp(sopflow->subproblem_solver, "HIOP", &issubproblemsolver_hiop);
+  ierr =
+      PetscStrcmp(sopflow->subproblem_solver, "HIOP", &issubproblemsolver_hiop);
   CHKERRQ(ierr);
   if (issubproblemsolver_hiop) {
     ierr = OPFLOWSetHIOPComputeMode(opflowscen, sopflow->compute_mode);

--- a/src/tcopflow/interface/tcopflowoutput.cpp
+++ b/src/tcopflow/interface/tcopflowoutput.cpp
@@ -38,7 +38,7 @@ PetscErrorCode TCOPFLOWPrintSolution(TCOPFLOW tcopflow, PetscInt t_num) {
       "=============================================================\n");
   CHKERRQ(ierr);
   ierr = PetscPrintf(tcopflow->comm->type, "%-35s %s\n", "OPFLOW Model",
-                     opflow->modelname.c_str());
+                     opflow->modelname);
   CHKERRQ(ierr);
   ierr = PetscPrintf(tcopflow->comm->type, "%-35s %s\n", "Solver",
                      tcopflow->solvername);


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [x] OPFLOW
- [x] SOPFLOW
- [x] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [x] Header files
- [x] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

This changes the storage of strings in structs that are allocated with `PetscCalloc` from `std::string` to `char[32]`. This essentially reverts a prior attempt to "modernize" the storage of strings, which comes with a few concerns. The application-level strings remain `std::string`, and they are converted to `char[]` for storage in the structs. 

After Frontier's recent OS upgrade, several tests were failing due to an obscure segmentation fault. 
```
62/62 Testing: SOPFLOW_SOLUTION_OUTPUT_MINIMAL
62/62 Test: SOPFLOW_SOLUTION_OUTPUT_MINIMAL
Command: "/usr/bin/srun" "/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO/build/applications/sopflow" "-netfile" "/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO/datafiles/case9/case9mod.m" "-ctgcfile" "/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO/datafiles/case9/case9.cont" "-scenfile" "/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO/datafiles/case9/10_scenarios_9bus.csv" "-sopflow_solver" "IPOPT" "-sopflow_Ns" "8" "-sopflow_Nc" "3" "-sopflow_enable_multicontingency" "1" "-sopflow_flatten_contingencies" "0" "-save_output" "1" "-opflow_output_format" "MINIMAL" "-sopflow_output_directory" "sopflowout_MINIMAL"
Directory: /lustre/orion/scratch/nkouk/stf006/Codes/ExaGO/build/tests/functionality/sopflow
"SOPFLOW_SOLUTION_OUTPUT_MINIMAL" start time: May 28 15:00 EDT
Output:
----------------------------------------------------------
[ExaGO] SOPFLOW: Application created
[ExaGO] SOPFLOW running with %d scenarios

[ExaGO] SOPFLOW: Using IPOPT solver

[ExaGO] SCOPFLOW: Application created
[ExaGO] SCOPFLOW running with 4 subproblems (base case + 3 contingencies)
[ExaGO] SCOPFLOW: Using IPOPT solver
[0]PETSC ERROR: ------------------------------------------------------------------------
[0]PETSC ERROR: Caught signal number 11 SEGV: Segmentation Violation, probably memory access out of range
[0]PETSC ERROR: Try option -start_in_debugger or -on_error_attach_debugger
[0]PETSC ERROR: or see https://petsc.org/release/faq/#valgrind and https://petsc.org/release/faq/
[0]PETSC ERROR: ---------------------  Stack Frames ------------------------------------
The line numbers in the error traceback are not always exact.
[0] #1 SCOPFLOWSetUp() at /lustre/orion/scratch/nkouk/stf006/Codes/ExaGO/src/scopflow/interface/scopflow.cpp:710
[0] #2 SOPFLOWSetUp() at /lustre/orion/scratch/nkouk/stf006/Codes/ExaGO/src/sopflow/interface/sopflow.cpp:1100
MPICH ERROR [Rank 0] [job id 4731080.144] [Thu May 28 15:00:58 2026] [frontier08535] - Abort(59) (rank 0 in comm 0): application called MPI_Abort(MPI_COMM_WORLD, 59) - process 0
```

The outstanding stack issue I recall seeing with Valgrind was the `std::string` values stored in the structs, where the appropriate destructors were not being called. The changes in this PR resolve the failing tests and the Valgrind errors.

We can revisit storing `std::string` in the structs if we also update the object allocation (e.g., with `new`) and deallocation. The memory would no longer be owned by PETSc. 
Relates to [this issue](https://github.com/pnnl/ExaGO/issues/31).